### PR TITLE
Fix card summary edit reverting to unchanged content

### DIFF
--- a/src/newtab-drawer-data.js
+++ b/src/newtab-drawer-data.js
@@ -400,7 +400,7 @@ export function createDrawerDataController({
     }
 
     const nextTitle = (updates.title || '').trim();
-    const nextDescription = (updates.description || '').trim();
+    const nextAiSummaryBrief = (updates.ai_summary_brief || '').trim();
     if (!nextTitle) {
       windowObj.alert('Title is required.');
       return;
@@ -412,13 +412,13 @@ export function createDrawerDataController({
     try {
       const response = await api.updatePage(id, {
         title: nextTitle,
-        description: nextDescription
+        ai_summary_brief: nextAiSummaryBrief
       });
       const applyResponseToPage = entry => ({
         ...entry,
         ...(response && typeof response === 'object' ? response : {}),
         title: nextTitle,
-        description: nextDescription
+        ai_summary_brief: nextAiSummaryBrief
       });
       updateDrawerPageCollections(id, applyResponseToPage);
       state.editingPageId = null;

--- a/src/newtab-drawer-events.js
+++ b/src/newtab-drawer-events.js
@@ -203,7 +203,7 @@ export function initSavedPagesDrawerEvents({
     const formData = new FormData(form);
     void handleDrawerUpdate(form.dataset.pageId, {
       title: formData.get('title') || '',
-      description: formData.get('description') || ''
+      ai_summary_brief: formData.get('ai_summary_brief') || ''
     });
   });
 

--- a/src/newtab-drawer-renderer.js
+++ b/src/newtab-drawer-renderer.js
@@ -20,7 +20,10 @@ export function renderDrawerCardMarkup(page, {
   const isEditing = page.id === editingPageId;
   const isSavingEdit = page.id === savingEditPageId;
   const domain = getPageDomain(page);
-  const rawSummary = page.description || page.ai_summary_brief || '';
+  // Show the AI summary, falling back to the scraped page description when the
+  // user clears the AI summary. Both fields are read-only here; the edit form
+  // writes ai_summary_brief.
+  const rawSummary = page.ai_summary_brief || page.description || '';
   const normalizedSummary = rawSummary.trim().toLowerCase();
   const normalizedTitle = (page.title || '').trim().toLowerCase();
   const normalizedDomain = (domain || '').trim().toLowerCase();
@@ -110,14 +113,14 @@ export function renderDrawerCardMarkup(page, {
         >
       </label>
       <label class="saved-pages-drawer-edit-field">
-        <span class="saved-pages-drawer-edit-label">Description</span>
+        <span class="saved-pages-drawer-edit-label">Summary</span>
         <textarea
           class="saved-pages-drawer-edit-textarea"
-          name="description"
+          name="ai_summary_brief"
           rows="4"
-          placeholder="Add a description"
+          placeholder="Add a summary"
           ${isSavingEdit ? 'disabled' : ''}
-        >${escapeHtml(page.description || '')}</textarea>
+        >${escapeHtml(page.ai_summary_brief || '')}</textarea>
       </label>
       <div class="saved-pages-drawer-edit-actions">
         <button

--- a/tests/e2e/standalone.spec.js
+++ b/tests/e2e/standalone.spec.js
@@ -144,7 +144,7 @@ test.describe('Standalone Mode', () => {
     await expect(page.locator('.saved-pages-drawer-card').first()).toContainText('SaveIt product');
   });
 
-  test('should edit a page title and description inline', async ({ page }) => {
+  test('should edit a page title and summary inline', async ({ page }) => {
     await showAllPages(page);
 
     // Cards are editable from the unfiltered browse view (search hides them
@@ -154,7 +154,7 @@ test.describe('Standalone Mode', () => {
     await card.locator('.saved-pages-drawer-edit-btn').click();
 
     await card.locator('input[name="title"]').fill('Edited Himalayan Journey');
-    await card.locator('textarea[name="description"]').fill('Updated description from Playwright.');
+    await card.locator('textarea[name="ai_summary_brief"]').fill('Updated summary from Playwright.');
     await card.locator('.saved-pages-drawer-edit-save').click();
 
     // The edited card is still in the unfiltered list with its new values.
@@ -164,7 +164,7 @@ test.describe('Standalone Mode', () => {
       .first();
     await expect(editedCard).toBeVisible();
     await expect(editedCard.locator('.saved-pages-drawer-card-title')).toContainText('Edited Himalayan Journey');
-    await expect(editedCard.locator('.saved-pages-drawer-card-summary')).toContainText('Updated description from Playwright.');
+    await expect(editedCard.locator('.saved-pages-drawer-card-summary')).toContainText('Updated summary from Playwright.');
 
     void originalTitle;
   });

--- a/tests/unit/newtab.test.js
+++ b/tests/unit/newtab.test.js
@@ -784,54 +784,68 @@ describe('newtab modules', () => {
 
       expect(markup).toContain('saved-pages-drawer-edit-form');
       expect(markup).toContain('name="title"');
-      expect(markup).toContain('name="description"');
+      expect(markup).toContain('name="ai_summary_brief"');
       expect(markup).toContain('data-action="cancel-edit"');
     });
 
-    it('does not fall back to ai_summary_brief when description is cleared', () => {
+    it('prefers ai_summary_brief and falls back to the page description', () => {
       const summaryClass = 'saved-pages-drawer-card-summary';
 
-      // User explicitly cleared the description (optimistic state right after save)
-      const clearedMarkup = renderDrawerCardMarkup({
+      // AI summary wins when both are present
+      const bothMarkup = renderDrawerCardMarkup({
         id: 'page-1',
         title: 'SaveIt',
-        description: '',
-        ai_summary_brief: 'AI-generated summary that should not show',
-        url: 'https://example.com/article'
-      }, {
-        getProjectPills: () => [],
-        projectsUnavailable: false
-      });
-      expect(clearedMarkup).not.toContain(summaryClass);
-      expect(clearedMarkup).not.toContain('AI-generated summary');
-
-      // Same after a reload: backend serializes a cleared description as null
-      const reloadedMarkup = renderDrawerCardMarkup({
-        id: 'page-1',
-        title: 'SaveIt',
-        description: null,
-        ai_summary_brief: 'AI-generated summary that should not show',
-        url: 'https://example.com/article'
-      }, {
-        getProjectPills: () => [],
-        projectsUnavailable: false
-      });
-      expect(reloadedMarkup).not.toContain(summaryClass);
-      expect(reloadedMarkup).not.toContain('AI-generated summary');
-
-      // Sanity: a real user description still renders
-      const withDescMarkup = renderDrawerCardMarkup({
-        id: 'page-1',
-        title: 'SaveIt',
-        description: 'My notes',
+        description: 'Page description',
         ai_summary_brief: 'AI-generated summary',
         url: 'https://example.com/article'
       }, {
         getProjectPills: () => [],
         projectsUnavailable: false
       });
-      expect(withDescMarkup).toContain(summaryClass);
-      expect(withDescMarkup).toContain('My notes');
+      expect(bothMarkup).toContain(summaryClass);
+      expect(bothMarkup).toContain('AI-generated summary');
+      expect(bothMarkup).not.toContain('Page description');
+
+      // Cleared AI summary (optimistic state right after save) falls back to description
+      const clearedMarkup = renderDrawerCardMarkup({
+        id: 'page-1',
+        title: 'SaveIt',
+        description: 'Page description',
+        ai_summary_brief: '',
+        url: 'https://example.com/article'
+      }, {
+        getProjectPills: () => [],
+        projectsUnavailable: false
+      });
+      expect(clearedMarkup).toContain(summaryClass);
+      expect(clearedMarkup).toContain('Page description');
+
+      // Same after a reload: backend serializes a cleared AI summary as null
+      const reloadedMarkup = renderDrawerCardMarkup({
+        id: 'page-1',
+        title: 'SaveIt',
+        description: 'Page description',
+        ai_summary_brief: null,
+        url: 'https://example.com/article'
+      }, {
+        getProjectPills: () => [],
+        projectsUnavailable: false
+      });
+      expect(reloadedMarkup).toContain(summaryClass);
+      expect(reloadedMarkup).toContain('Page description');
+
+      // Nothing to show when both are empty
+      const emptyMarkup = renderDrawerCardMarkup({
+        id: 'page-1',
+        title: 'SaveIt',
+        description: '',
+        ai_summary_brief: null,
+        url: 'https://example.com/article'
+      }, {
+        getProjectPills: () => [],
+        projectsUnavailable: false
+      });
+      expect(emptyMarkup).not.toContain(summaryClass);
     });
   });
 
@@ -1213,13 +1227,13 @@ describe('newtab modules', () => {
      });
    });
 
-   it('updates page title and description inline and re-applies filters', async () => {
+   it('updates page title and summary inline and re-applies filters', async () => {
      const { controller, state, api, savedPagesView, applyDrawerFilters, dependencies } = createDrawerDataHarness({
        state: {
          query: 'alpha',
          editingPageId: 'page-1',
-         pages: [{ id: 'page-1', title: 'Alpha', description: 'Before', pinned: false }],
-         allPages: [{ id: 'page-1', title: 'Alpha', description: 'Before', pinned: false }]
+         pages: [{ id: 'page-1', title: 'Alpha', ai_summary_brief: 'Before', pinned: false }],
+         allPages: [{ id: 'page-1', title: 'Alpha', ai_summary_brief: 'Before', pinned: false }]
        },
        api: {
          updatePage: vi.fn().mockResolvedValue({ updated_at: '2026-05-26T00:00:00.000Z' })
@@ -1228,12 +1242,12 @@ describe('newtab modules', () => {
 
      await controller.handleDrawerUpdate('page-1', {
        title: 'Alpha edited',
-       description: 'After'
+       ai_summary_brief: 'After'
      });
 
      expect(api.updatePage).toHaveBeenCalledWith('page-1', {
        title: 'Alpha edited',
-       description: 'After'
+       ai_summary_brief: 'After'
      });
      expect(savedPagesView.persistAllPages).toHaveBeenCalled();
      expect(applyDrawerFilters).toHaveBeenCalledWith('alpha');
@@ -1242,7 +1256,7 @@ describe('newtab modules', () => {
      expect(state.savingEditPageId).toBeNull();
     expect(state.allPages[0]).toMatchObject({
       title: 'Alpha edited',
-      description: 'After'
+      ai_summary_brief: 'After'
     });
   });
 


### PR DESCRIPTION
## Problem

Editing a saved card's summary appeared not to save: after clearing the summary and saving, the card reverted to the unchanged content.

## Root cause

Field mismatch between display and edit:
- The card **displayed** `ai_summary_brief` (via the `description || ai_summary_brief` fallback).
- The edit form **wrote** a different field — `description` — which was empty in exactly that case.

So opening a card showing an AI summary presented a blank textarea; "deleting" the summary saved an empty `description`, and the displayed AI summary never changed.

## Fix

Make display and edit consistent on `ai_summary_brief`, with the scraped page `description` as the read-only fallback when the summary is cleared (matches the existing favorites/hover-card priority).

- **Display priority** (`newtab-drawer-renderer.js`): `ai_summary_brief || description`.
- **Edit textarea** binds to `ai_summary_brief` (label "Summary").
- **`handleDrawerUpdate`** sends and force-applies `ai_summary_brief`.
- Tests rewritten for the new contract (priority, edit form field, `updatePage` payload).

## Backend dependency — ✅ deployed

The backend `PATCH /updatePage` now accepts and persists `ai_summary_brief`. The change is **additive** (old extension versions keep working). Backend changes shipped:
- `cloud-function/index.js` `handlePatchPage` — destructure + forward `ai_summary_brief`
- `cloud-function/validation.js` — whitelist `ai_summary_brief` + string type check
- `cloud-function/firestore-update.js` `updateThingFields` — write `ai_summary_brief`

## Verification

- `just test` — 342/342 pass
- `just lint-js` — clean
- `just check` full suite via pre-commit hook — pass