### PR TITLE
Lazy-render the All-pages view and fetch the rest on scroll

### DIFF
--- a/src/newtab-drawer-data.js
+++ b/src/newtab-drawer-data.js
@@ -1,6 +1,10 @@
 import { PINNED_PAGES_SCOPE_ID } from './project-manager-state.js';
 import { canHydrateDrawerWithWarmCache } from './newtab-drawer-coordination.js';
 import { createDomainSavedPagesStore, createProjectSavedPagesStore } from './newtab-drawer-stores.js';
+import {
+  INITIAL_RENDER_LIMIT,
+  RENDER_LIMIT_INCREMENT
+} from './newtab-drawer-state.js';
 import { hasRenderableWarmCache, upsertListPages } from './warm-cache-list-store.js';
 
 export function createDrawerDataController({
@@ -255,6 +259,7 @@ export function createDrawerDataController({
 
     const requestId = ++state.requestId;
     const trimmedQuery = query.trim();
+    resetRenderLimit();
 
     state.isLoading = true;
     setDrawerSearchValue(trimmedQuery);
@@ -516,6 +521,10 @@ export function createDrawerDataController({
   async function loadDrawerResults(query = '', { syncUrl = true } = {}) {
     const trimmedQuery = query.trim();
 
+    // A new query re-filters in memory; start the render window fresh so the
+    // first matches paint immediately and scroll re-grows it.
+    resetRenderLimit();
+
     // Any search intent (typed, submitted, cleared, topic-pill click) leaves
     // the sparse home view for the browse list.
     state.view = 'browse';
@@ -565,6 +574,7 @@ export function createDrawerDataController({
 
     // Selecting a domain scope leaves the sparse home view.
     state.view = 'browse';
+    resetRenderLimit();
     const requestId = ++state.requestId;
     const trimmedQuery = query.trim();
 
@@ -624,6 +634,51 @@ export function createDrawerDataController({
     }
   }
 
+  function resetRenderLimit() {
+    state.renderLimit = INITIAL_RENDER_LIMIT;
+  }
+
+  // Track in-flight lazy loads so concurrent scroll events don't stack calls.
+  let lazyLoadInFlight = false;
+
+  // Called by the scroll handler when the user nears the bottom of the list.
+  // Grows the render window, and — for the All-pages scope only — asks the
+  // store for the next cursor batch once we're rendering past what's in memory.
+  async function handleDrawerScrollNearEnd() {
+    const hasScope = Boolean(state.selectedProjectId) || Boolean(state.selectedDomainId);
+
+    // Project/domain views are not windowed; nothing to grow.
+    if (hasScope) {
+      return;
+    }
+
+    const fullCount = state.pages.length;
+    if (state.renderLimit < fullCount) {
+      state.renderLimit += RENDER_LIMIT_INCREMENT;
+      renderDrawerResults();
+    }
+
+    // If the render window already covers everything we have in memory, but the
+    // server still has more, fetch the next batch. The store's change event
+    // re-renders on arrival.
+    const snapshot = savedPagesStore.getSnapshot();
+    if (
+      !lazyLoadInFlight
+      && state.renderLimit >= state.allPages.length
+      && snapshot?.hasNextPage
+      && !snapshot?.isLoadingMore
+    ) {
+      lazyLoadInFlight = true;
+      try {
+        await savedPagesStore.loadMore();
+      } catch (error) {
+        console.error('[newtab] Lazy loadMore failed:', error);
+      } finally {
+        lazyLoadInFlight = false;
+      }
+    }
+  }
+
   return {
     ensureDrawerDomainsLoaded,
     ensureDrawerProjectsLoaded,
@@ -631,11 +686,13 @@ export function createDrawerDataController({
     handleDrawerEditCancel,
     handleDrawerEditStart,
     handleDrawerPin,
+    handleDrawerScrollNearEnd,
     handleDrawerUpdate,
     loadDrawerBasePages,
     loadDrawerDomainPages,
     loadDrawerProjectPages,
     loadDrawerResults,
-    loadSemanticResults
+    loadSemanticResults,
+    resetRenderLimit
   };
 }

--- a/src/newtab-drawer-events.js
+++ b/src/newtab-drawer-events.js
@@ -32,6 +32,7 @@ export function initSavedPagesDrawerEvents({
   handleDrawerPin,
   handleDrawerUpdate,
   handleDrawerDelete,
+  handleDrawerScrollNearEnd,
   setDrawerSearchValue,
   setDrawerToggleState,
   isDrawerOpen,
@@ -302,6 +303,42 @@ export function initSavedPagesDrawerEvents({
       projectManager.closeEditor(savedPagesView);
     }
   });
+  // Lazy-load more saved pages as the user scrolls toward the bottom of the
+  // results pane. Throttled per frame to avoid firing on every scroll event.
+  // Listens on the results container (the bounded scroll viewport) and on the
+  // window as a fallback for the narrow-width layout where the window scrolls.
+  let scrollRafQueued = false;
+  function onScrollNearEnd() {
+    if (scrollRafQueued) {
+      return;
+    }
+    scrollRafQueued = true;
+    windowObj.requestAnimationFrame(() => {
+      scrollRafQueued = false;
+      void handleDrawerScrollNearEnd?.();
+    });
+  }
+  function isNearScrollEnd(el) {
+    if (!el) {
+      return false;
+    }
+    const threshold = el.clientHeight * 1.5;
+    return el.scrollTop + el.clientHeight >= el.scrollHeight - threshold;
+  }
+  savedPagesDrawerResults?.addEventListener('scroll', () => {
+    if (isNearScrollEnd(savedPagesDrawerResults)) {
+      onScrollNearEnd();
+    }
+  }, { passive: true });
+  windowObj.addEventListener('scroll', () => {
+    // Only acts as a fallback when the results container itself isn't the
+    // scroller (narrow layout). handleDrawerScrollNearEnd is a no-op for
+    // project/domain scopes, so this stays safe.
+    if (isNearScrollEnd(windowObj.document.scrollingElement)) {
+      onScrollNearEnd();
+    }
+  }, { passive: true });
+
   void openSavedPagesDrawer;
   setDrawerToggleState(true);
   setDrawerSearchValue(getInitialDrawerUrlState(windowObj.location.search).searchQuery);

--- a/src/newtab-drawer-renderer.js
+++ b/src/newtab-drawer-renderer.js
@@ -241,11 +241,16 @@ export function createDrawerRenderer({
     renderChrome();
   }
 
-  function renderLoadingState(message = 'Gathering your saved pages…') {
+  // Cold-start loading state. Reuses the semantic-search digging-dog
+  // illustration (theme-aware via currentColor, reduced-motion safe) so a
+  // genuinely empty warm cache shows the same friendly loader rather than a
+  // bare spinner + "Gathering…" copy. The message arg is accepted for
+  // signature compatibility but intentionally not rendered: the dog reads as
+  // "loading" without text, which avoids the brief flash of copy swapping in.
+  function renderLoadingState(_message) {
     renderDrawerState(`
-      <div class="saved-pages-drawer-state">
-        <div class="saved-pages-drawer-spinner" aria-hidden="true"></div>
-        <p>${escapeHtml(message)}</p>
+      <div class="saved-pages-semantic-loading saved-pages-semantic-loading-pane" aria-live="polite">
+        ${LOADING_ILLUSTRATION_SVG}
       </div>
     `);
   }

--- a/src/newtab-drawer-renderer.js
+++ b/src/newtab-drawer-renderer.js
@@ -209,6 +209,7 @@ export function createDrawerRenderer({
   resultsContainer,
   getEditingPageId,
   getSavingEditPageId,
+  getRenderLimit,
   renderChrome,
   getProjectPills,
   isProjectsUnavailable,
@@ -331,7 +332,16 @@ export function createDrawerRenderer({
       return;
     }
 
-    reconcileKeyedChildren(pagesSection, pages, {
+    // Render a windowed slice. `pages` holds the full filtered set (needed for
+    // count math and load-more decisions); only the first `renderLimit` cards
+    // become DOM nodes. reconcileKeyedChildren reuses existing nodes by key, so
+    // growing the window only creates the newly-revealed cards.
+    const renderLimit = typeof getRenderLimit === 'function' ? getRenderLimit() : pages.length;
+    const visiblePages = Number.isFinite(renderLimit) && renderLimit < pages.length
+      ? pages.slice(0, renderLimit)
+      : pages;
+
+    reconcileKeyedChildren(pagesSection, visiblePages, {
       getKey: page => page.id || null,
       getNodeKey: node => node?.dataset?.pageId || null,
       pruneUnkeyed: true,

--- a/src/newtab-drawer-runtime.js
+++ b/src/newtab-drawer-runtime.js
@@ -159,6 +159,7 @@ export function createSavedPagesDrawerController({
       handleDrawerPin: dataController.handleDrawerPin,
       handleDrawerUpdate: dataController.handleDrawerUpdate,
       handleDrawerDelete: dataController.handleDrawerDelete,
+      handleDrawerScrollNearEnd: dataController.handleDrawerScrollNearEnd,
       setDrawerSearchValue: shellController.setDrawerSearchValue,
       setDrawerToggleState: shellController.setDrawerToggleState,
       isDrawerOpen: shellController.isDrawerOpen,

--- a/src/newtab-drawer-state.js
+++ b/src/newtab-drawer-state.js
@@ -1,5 +1,10 @@
 import { PINNED_PAGES_SCOPE_ID } from './project-manager-state.js';
 
+// Render windowing for the All-pages browse view. Only this many cards render
+// on first paint; scrolling grows the window by RENDER_LIMIT_INCREMENT.
+export const INITIAL_RENDER_LIMIT = 10;
+export const RENDER_LIMIT_INCREMENT = 100;
+
 export function createInitialDrawerState() {
   return {
     hasInitialized: false,
@@ -15,6 +20,9 @@ export function createInitialDrawerState() {
     },
     pages: [],
     allPages: [],
+    // Cap on how many of `pages` are rendered to the DOM. Grown on scroll;
+    // reset to INITIAL_RENDER_LIMIT whenever the scope or query changes.
+    renderLimit: INITIAL_RENDER_LIMIT,
     loadedProjectPages: null,
     projects: [],
     projectsLoading: false,

--- a/src/newtab-drawer-stores.js
+++ b/src/newtab-drawer-stores.js
@@ -34,6 +34,9 @@ export function createSavedPagesStore(api) {
     initialFetchLimit: DRAWER_INITIAL_FETCH_LIMIT,
     prefetchBatchLimit: 100,
     pinnedFirst: true,
+    // The All-pages view renders a windowed slice and fetches further pages on
+    // scroll, so the store must not eagerly drain the whole collection.
+    lazy: true,
     warmCacheScope: DRAWER_WARM_CACHE_SCOPE
   });
 }

--- a/src/newtab-drawer-ui.js
+++ b/src/newtab-drawer-ui.js
@@ -44,6 +44,12 @@ export function createDrawerUiController({
     resultsContainer,
     getEditingPageId: () => state.editingPageId,
     getSavingEditPageId: () => state.savingEditPageId,
+    // Render-window cap (All-pages browse view only); grown on scroll. Scoped
+    // views (project/domain) are not windowed, so they bypass the cap.
+    getRenderLimit: () => {
+      const hasScope = Boolean(state.selectedProjectId) || Boolean(state.selectedDomainId);
+      return hasScope ? Number.POSITIVE_INFINITY : state.renderLimit;
+    },
     renderChrome: renderDrawerChrome,
     getProjectPills: page => getDrawerProjectPills(page),
     isProjectsUnavailable: () => getSavedPagesViewOrThrow().projectsAvailable === false,

--- a/src/newtab-page.js
+++ b/src/newtab-page.js
@@ -59,7 +59,12 @@ export async function startNewtabPage({
   ThemeManager.init('hero-theme-toggle-container');
   updateVersionIndicator(versionNumberEl);
   drawerController.init();
-  drawerController.showLoadingState?.('Gathering your saved pages…');
+
+  // Do NOT paint an eager loading state here. The results pane starts empty
+  // and the warm-cache path renders real content directly on first paint;
+  // an interim spinner here causes a flash of unstyled state (blank →
+  // spinner → content). Cold starts show the loading dog from within
+  // loadDrawerBasePages once it confirms there's no warm cache to render.
 
   // Resolve auth BEFORE loading the drawer. The drawer's initial hydrate()
   // runs a freshness check (headSavedPages) that needs a signed-in user to

--- a/src/warm-cache-list-store.js
+++ b/src/warm-cache-list-store.js
@@ -142,6 +142,11 @@ export class WarmCacheListStore {
       maxItems: options.maxItems || Number.POSITIVE_INFINITY,
       initialFetchLimit: options.initialFetchLimit || 50,
       prefetchBatchLimit: options.prefetchBatchLimit || 100,
+      // When true, the store fetches only the initial batch and stops. Callers
+      // drive further fetching via loadMore() (e.g. on scroll). The warm-cache
+      // and freshness-check paths still run; only the eager full prefetch is
+      // suppressed.
+      lazy: options.lazy === true,
       warmCacheScope: options.warmCacheScope || null,
       getList: options.getList || null,
       getIncrementalList: options.getIncrementalList || null,
@@ -540,6 +545,13 @@ export class WarmCacheListStore {
   }
 
   async prefetchAllPages(requestId = this.state.requestId) {
+    // Lazy stores fetch only the initial batch; further fetching is driven by
+    // explicit loadMore() calls (e.g. on scroll). This keeps large libraries
+    // from hydrating in full on first paint.
+    if (this.options.lazy) {
+      return this.getSnapshot();
+    }
+
     while (
       this.state.requestId === requestId &&
       this.getActiveHasNextPage(requestId) &&

--- a/tests/e2e/standalone.spec.js
+++ b/tests/e2e/standalone.spec.js
@@ -169,6 +169,36 @@ test.describe('Standalone Mode', () => {
     void originalTitle;
   });
 
+  test('renders a windowed slice and grows the list on scroll (lazy render)', async ({ page }) => {
+    await showAllPages(page);
+
+    const cards = page.locator('.saved-pages-drawer-card');
+    // First paint renders only the initial window; the mock dataset is much
+    // larger (~176 items), so this proves the list is windowed, not full.
+    await expect(cards).toHaveCount(10, { timeout: 5000 });
+
+    // Scroll the results pane to the bottom to trigger the growth handler.
+    const results = page.locator('#saved-pages-results');
+    await results.evaluate(el => {
+      el.scrollTop = el.scrollHeight;
+    });
+    // Fire a second scroll after a tick to push past the rAF throttle.
+    await page.waitForTimeout(50);
+    await results.evaluate(el => {
+      el.scrollTop = el.scrollHeight;
+    });
+
+    // The window grew beyond the initial 10 (one or more increments of 100,
+    // capped at the dataset size). Assert a range rather than an exact count so
+    // the test is robust to how many throttled scroll events fire.
+    await expect(async () => {
+      const count = await cards.count();
+      expect(count).toBeGreaterThan(10);
+    }).toPass({ timeout: 5000 });
+    const finalCount = await cards.count();
+    expect(finalCount).toBeGreaterThanOrEqual(110);
+  });
+
   test('tags on cards keep roughly one character of horizontal space between them', async ({ page }) => {
     await showAllPages(page);
 
@@ -354,16 +384,31 @@ test.describe('Standalone Mode', () => {
     // The selected domain row is active.
     await expect(firstDomain.locator('.project-nav-item')).toHaveClass(/is-active/);
 
-    // Cards render for the scoped domain — fewer than the full list, proving
-    // the list was actually filtered (not all pages).
+    // Cards render for the scoped domain — proving the list was actually
+    // filtered to that domain (scoped views are not render-windowed).
     await expect(page.locator('.saved-pages-drawer-card').first()).toBeVisible({ timeout: 5000 });
     const scopedCount = await page.locator('.saved-pages-drawer-card').count();
     expect(scopedCount).toBeGreaterThan(0);
 
-    // Switch back to All pages and confirm the count is higher (unscoped).
+    // Switch back to All pages. The unscoped list is render-windowed (first 10),
+    // so comparing raw counts no longer proves re-filtering. Instead, scroll to
+    // grow the All-pages window and confirm the unscoped set is larger than the
+    // scoped slice — i.e. the domain filter was removed.
     await page.locator('.project-nav-item[data-project-id=""]').click();
-    await page.waitForTimeout(500);
-    const allCount = await page.locator('.saved-pages-drawer-card').count();
-    expect(allCount).toBeGreaterThan(scopedCount);
+    await expect(page.locator('.saved-pages-drawer-card')).toHaveCount(10, { timeout: 5000 });
+
+    const results = page.locator('#saved-pages-results');
+    await results.evaluate(el => {
+      el.scrollTop = el.scrollHeight;
+    });
+    await page.waitForTimeout(50);
+    await results.evaluate(el => {
+      el.scrollTop = el.scrollHeight;
+    });
+
+    await expect(async () => {
+      const allCount = await page.locator('.saved-pages-drawer-card').count();
+      expect(allCount).toBeGreaterThan(scopedCount);
+    }).toPass({ timeout: 5000 });
   });
 });

--- a/tests/unit/newtab-drawer-renderer.test.js
+++ b/tests/unit/newtab-drawer-renderer.test.js
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createDrawerRenderer } from '../../src/newtab-drawer-renderer.js';
+
+// Minimal renderer harness: a real results container and a no-op renderChrome
+// so renderLoadingState can be exercised in isolation. The loading state is a
+// full-pane swap of the results container, so we only need the container.
+function createRenderer() {
+  const resultsContainer = document.createElement('div');
+  return {
+    resultsContainer,
+    renderer: createDrawerRenderer({
+      documentObj: document,
+      resultsContainer,
+      getEditingPageId: () => null,
+      getSavingEditPageId: () => null,
+      getRenderLimit: () => Number.POSITIVE_INFINITY,
+      renderChrome: () => {},
+      getProjectPills: () => [],
+      isProjectsUnavailable: () => false,
+      getProjectScopeLabel: () => 'All pages'
+    })
+  };
+}
+
+describe('newtab drawer renderer loading state', () => {
+  it('renders the digging-dog illustration, not a spinner or loading copy', () => {
+    const { resultsContainer, renderer } = createRenderer();
+
+    renderer.renderLoadingState();
+
+    const html = resultsContainer.innerHTML;
+    expect(html).toContain('saved-pages-semantic-loading-pane');
+    // The waggy-dog SVG is the loader; its presence is the contract.
+    expect(html).toContain('loading-dog-body');
+    // The old spinner element and "Gathering…" copy must be gone — they caused
+    // a flash of unstyled state on first paint.
+    expect(html).not.toContain('saved-pages-drawer-spinner');
+    expect(html).not.toContain('Gathering');
+  });
+
+  it('ignores the message argument (copy is intentionally not rendered)', () => {
+    const { resultsContainer, renderer } = createRenderer();
+
+    // Cold-start callers still pass scope-specific copy; the renderer must not
+    // paint it, since swapping text in/out causes a visible flash.
+    renderer.renderLoadingState('Searching project pages…');
+
+    expect(resultsContainer.innerHTML).not.toContain('Searching project pages');
+    expect(resultsContainer.innerHTML).toContain('loading-dog-body');
+  });
+
+  it('renders the dog even when called with no arguments', () => {
+    const { resultsContainer, renderer } = createRenderer();
+
+    renderer.renderLoadingState();
+
+    expect(resultsContainer.innerHTML).toContain('loading-dog-body');
+  });
+
+  it('invokes renderChrome so surrounding chrome stays consistent', () => {
+    const renderChrome = vi.fn();
+    const resultsContainer = document.createElement('div');
+    const renderer = createDrawerRenderer({
+      documentObj: document,
+      resultsContainer,
+      getRenderLimit: () => Number.POSITIVE_INFINITY,
+      renderChrome,
+      getProjectPills: () => [],
+      isProjectsUnavailable: () => false,
+      getProjectScopeLabel: () => 'All pages'
+    });
+
+    renderer.renderLoadingState();
+
+    expect(renderChrome).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/newtab-drawer-runtime.test.js
+++ b/tests/unit/newtab-drawer-runtime.test.js
@@ -99,7 +99,9 @@ describe('newtab drawer runtime', () => {
     expect(controller.handleSignedIn).toBe(syncCoordinator.handleSignedIn);
     expect(controller.handleSignedOut).toBe(syncCoordinator.handleSignedOut);
     expect(controller.preloadProjects).toBe(dataController.ensureDrawerProjectsLoaded);
-    controller.showLoadingState('Gathering your saved pages…');
-    expect(uiController.renderLoadingState).toHaveBeenCalledWith('Gathering your saved pages…');
+    // showLoadingState forwards to the UI controller's loading renderer.
+    // The argument is opaque passthrough; the renderer decides what to paint.
+    controller.showLoadingState();
+    expect(uiController.renderLoadingState).toHaveBeenCalled();
   });
 });

--- a/tests/unit/newtab.test.js
+++ b/tests/unit/newtab.test.js
@@ -233,13 +233,14 @@ describe('newtab modules', () => {
 
         await Promise.resolve();
 
-        // Theme/version/init/showLoadingState run immediately, but the drawer
-        // must NOT load before auth resolves — its hydrate() freshness check
-        // needs a signed-in user to mint an auth token.
+        // Theme/version/init run immediately, but the drawer must NOT load or
+        // paint a loading state before auth resolves. An eager loading state
+        // here flashes on screen before the warm cache can render real content,
+        // so startup must defer all rendering until load() runs.
         expect(ThemeManager.init).toHaveBeenCalledWith('hero-theme-toggle-container');
         expect(updateVersionIndicator).toHaveBeenCalledWith({ id: 'version' });
         expect(drawerController.init).toHaveBeenCalled();
-        expect(drawerController.showLoadingState).toHaveBeenCalledWith('Gathering your saved pages…');
+        expect(drawerController.showLoadingState).not.toHaveBeenCalled();
         expect(drawerController.load).not.toHaveBeenCalled();
         expect(drawerController.preloadProjects).not.toHaveBeenCalled();
         expect(authController.init).toHaveBeenCalled();
@@ -275,7 +276,7 @@ describe('newtab modules', () => {
         });
 
         expect(drawerController.init).toHaveBeenCalled();
-        expect(drawerController.showLoadingState).toHaveBeenCalledWith('Gathering your saved pages…');
+        expect(drawerController.showLoadingState).not.toHaveBeenCalled();
         expect(drawerController.preloadProjects).toHaveBeenCalled();
         expect(drawerController.load).toHaveBeenCalled();
       });

--- a/tests/unit/newtab.test.js
+++ b/tests/unit/newtab.test.js
@@ -21,6 +21,7 @@ import {
   startNewtabPage
 } from '../../src/newtab-page.js';
 import {
+  createDrawerRenderer,
   getDrawerEmptyStateContent,
   renderDrawerCardMarkup
 } from '../../src/newtab-drawer-renderer.js';
@@ -1257,6 +1258,166 @@ describe('newtab modules', () => {
     expect(state.allPages[0]).toMatchObject({
       title: 'Alpha edited',
       ai_summary_brief: 'After'
+    });
+  });
+
+  describe('render windowing', () => {
+    function makePages(count) {
+      return Array.from({ length: count }, (_, i) => ({
+        id: `page-${i + 1}`,
+        title: `Page ${i + 1}`,
+        url: `https://example.com/${i + 1}`
+      }));
+    }
+
+    function makeRenderer({ renderLimit }) {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const renderer = createDrawerRenderer({
+        documentObj: document,
+        resultsContainer: container,
+        getRenderLimit: () => renderLimit,
+        renderChrome: () => {},
+        getProjectPills: () => [],
+        isProjectsUnavailable: () => false,
+        getProjectScopeLabel: () => 'All pages'
+      });
+      return { container, renderer, setRenderLimit: v => { renderLimit = v; } };
+    }
+
+    it('renders only the first renderLimit cards', () => {
+      const { container, renderer } = makeRenderer({ renderLimit: 10 });
+      renderer.renderResults(makePages(150));
+
+      expect(container.querySelectorAll('.saved-pages-drawer-card')).toHaveLength(10);
+    });
+
+    it('grows the rendered window when renderLimit increases, reusing existing nodes', () => {
+      let renderLimit = 10;
+      const { container, renderer, setRenderLimit } = makeRenderer({ renderLimit });
+      renderer.renderResults(makePages(150));
+      const firstCardBefore = container.querySelector('.saved-pages-drawer-card');
+
+      setRenderLimit(110);
+      renderer.renderResults(makePages(150));
+
+      expect(container.querySelectorAll('.saved-pages-drawer-card')).toHaveLength(110);
+      // Keyed reconciliation reuses the first node rather than rebuilding it.
+      expect(container.querySelector('.saved-pages-drawer-card')).toBe(firstCardBefore);
+    });
+
+    it('renders all pages when renderLimit is at or beyond the count', () => {
+      const { container, renderer } = makeRenderer({ renderLimit: 1000 });
+      renderer.renderResults(makePages(25));
+
+      expect(container.querySelectorAll('.saved-pages-drawer-card')).toHaveLength(25);
+    });
+  });
+
+  describe('handleDrawerScrollNearEnd', () => {
+    function pages(count) {
+      return Array.from({ length: count }, (_, i) => ({
+        id: `page-${i + 1}`,
+        title: `Page ${i + 1}`,
+        url: `https://example.com/${i + 1}`
+      }));
+    }
+
+    it('grows the render window and does not fetch when there is in-memory coverage', async () => {
+      const loadMore = vi.fn(async () => ({ status: 'updated' }));
+      const { controller, state, savedPagesStore, dependencies } = createDrawerDataHarness({
+        state: {
+          hasInitialized: true,
+          renderLimit: 10,
+          allPages: pages(150),
+          pages: pages(150)
+        },
+        savedPagesStore: {
+          getSnapshot: vi.fn(() => ({
+            allPages: pages(150),
+            total: 150,
+            hasNextPage: true,
+            isLoadingMore: false
+          })),
+          loadMore
+        }
+      });
+
+      await controller.handleDrawerScrollNearEnd();
+
+      expect(state.renderLimit).toBe(110);
+      // We still have in-memory pages beyond the window, so no fetch yet.
+      expect(loadMore).not.toHaveBeenCalled();
+      expect(dependencies.renderDrawerResults).toHaveBeenCalled();
+    });
+
+    it('calls loadMore once the render window passes in-memory coverage', async () => {
+      const loadMore = vi.fn(async () => ({ status: 'updated' }));
+      const { controller, state, savedPagesStore } = createDrawerDataHarness({
+        state: {
+          hasInitialized: true,
+          // Window already covers the 50 in-memory pages -> next scroll fetches.
+          renderLimit: 110,
+          allPages: pages(50),
+          pages: pages(50)
+        },
+        savedPagesStore: {
+          getSnapshot: vi.fn(() => ({
+            allPages: pages(50),
+            total: 200,
+            hasNextPage: true,
+            isLoadingMore: false
+          })),
+          loadMore
+        }
+      });
+
+      await controller.handleDrawerScrollNearEnd();
+
+      expect(loadMore).toHaveBeenCalledTimes(1);
+      expect(state.renderLimit).toBe(110);
+    });
+
+    it('is a no-op for project/domain scopes', async () => {
+      const loadMore = vi.fn(async () => ({ status: 'updated' }));
+      const { controller, state } = createDrawerDataHarness({
+        state: {
+          hasInitialized: true,
+          renderLimit: 10,
+          selectedProjectId: 'project-1',
+          allPages: pages(150),
+          pages: pages(150)
+        },
+        savedPagesStore: { loadMore }
+      });
+
+      await controller.handleDrawerScrollNearEnd();
+
+      // Scope guard returns before touching renderLimit or the store.
+      expect(state.renderLimit).toBe(10);
+      expect(loadMore).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resetRenderLimit', () => {
+    it('resets renderLimit to the initial value on a new query', async () => {
+      const allPages = Array.from({ length: 150 }, (_, i) => ({
+        id: `page-${i + 1}`,
+        title: `Page ${i + 1}`,
+        url: `https://example.com/${i + 1}`
+      }));
+      const { controller, state } = createDrawerDataHarness({
+        state: {
+          hasInitialized: true,
+          renderLimit: 210,
+          allPages,
+          pages: [...allPages]
+        }
+      });
+
+      await controller.loadDrawerResults('new query');
+
+      expect(state.renderLimit).toBe(10);
     });
   });
 

--- a/tests/unit/warm-cache-list-store.test.js
+++ b/tests/unit/warm-cache-list-store.test.js
@@ -109,6 +109,49 @@ describe('WarmCacheListStore', () => {
     expect(getList).toHaveBeenCalledTimes(2);
   });
 
+  it('does not prefetch beyond the initial batch when lazy, but honors explicit loadMore', async () => {
+    const firstBatch = makePages(50);
+    const secondBatch = makePages(40, 51);
+    const getList = vi
+      .fn()
+      .mockResolvedValueOnce({
+        pages: firstBatch,
+        pagination: {
+          total: 90,
+          hasNextPage: true,
+          nextCursor: 'page-50'
+        },
+        meta: {
+          fromCache: false
+        }
+      })
+      .mockResolvedValueOnce({
+        pages: secondBatch,
+        pagination: {
+          total: 90,
+          hasNextPage: false,
+          nextCursor: null
+        },
+        meta: {
+          fromCache: false
+        }
+      });
+    const { store } = createStore({ getList }, { lazy: true });
+
+    await store.hydrate();
+    // Give any stray background work a chance, then assert no prefetch happened.
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(store.getSnapshot().allPages).toHaveLength(50);
+    expect(getList).toHaveBeenCalledTimes(1);
+
+    // An explicit loadMore (as driven by scroll) still fetches the next batch.
+    await store.loadMore();
+
+    expect(store.getSnapshot().allPages).toHaveLength(90);
+    expect(getList).toHaveBeenCalledTimes(2);
+  });
+
   it('drops stale cached entries once a full authoritative refresh completes', async () => {
     const cachedPages = makePages(5);
     const getList = vi


### PR DESCRIPTION
## Problem
New-tab first paint was slow for users with many saved pages: the store **eagerly fetched the entire collection** (`prefetchAllPages` on hydrate), then the drawer rendered **every page as a DOM node** (no slice, no cap). Both network hydration and DOM build were unbounded.

## Fix
Two changes, scoped to the **All-pages browse view only** (project/domain views unchanged):

**1. Render windowing.** Only the first 10 cards render on load; scrolling grows the render window by 100. `reconcileKeyedChildren` already reuses existing nodes by key, so growth only creates the newly-revealed cards and preserves scroll position. `renderLimit` resets to 10 on scope/query change.

**2. Lazy fetching.** New `lazy` store option makes `prefetchAllPages` a no-op, so the saved-pages store fetches the initial batch (50) and stops. Scroll drives cursor `loadMore` once the render window passes the in-memory set and the server still has pages (`hasNextPage && !isLoadingMore`).

The pagination primitives (`loadMore`, `hasNextPage`, `nextCursor`, cursor contract) already existed — this wires them to a scroll handler instead of the eager prefetch.

### Files
- `warm-cache-list-store.js` — `lazy` option; no-op `prefetchAllPages` when set
- `newtab-drawer-stores.js` — `createSavedPagesStore` passes `lazy: true`
- `newtab-drawer-state.js` — `renderLimit` + `INITIAL_RENDER_LIMIT`/`RENDER_LIMIT_INCREMENT`
- `newtab-drawer-renderer.js` — slice pages by `getRenderLimit` in `renderResults`
- `newtab-drawer-data.js` — `handleDrawerScrollNearEnd` + `resetRenderLimit`
- `newtab-drawer-events.js` — `requestAnimationFrame`-throttled scroll listener (results container + window fallback for narrow layout)
- `newtab-drawer-ui.js` — scope-aware `getRenderLimit` (scoped views bypass the cap)
- `newtab-drawer-runtime.js` — wire `handleDrawerScrollNearEnd`

## Also: remove first-paint loading FOUC

The eager "Gathering your saved pages…" spinner painted before the drawer knew whether it had data, so warm-cache loads flashed blank → spinner → content. Startup now defers all rendering until real data lands:

- `newtab-page.js` — drop the synchronous eager `showLoadingState` call
- `newtab-drawer-renderer.js` — `renderLoadingState` emits the theme-aware digging-dog illustration (replacing the bare spinner + copy) for the cold-start path only
- Tests updated to assert no eager loading state; new renderer test covers the loader output

## Verification
- `just test` — 354/354 (added: store lazy mode, renderer slice + node reuse, scroll-handler window growth + loadMore gating, reset on query, loading-state renderer output)
- `just test-e2e` — 15/15 (new: initial count is 10, grows on scroll; updated the Domains scoping test for windowing)
- `just lint`, `just format-check`, `just validate`, `just build-all` — all green
- Pre-commit full check passed

## Notes / out of scope
- Scoped views (project/domain) are intentionally unwindowed — they keep eager prefetch + full render.