### PR TITLE
ci(release): publish to Chrome Web Store on every tag release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,20 +135,14 @@ jobs:
 
           ---
 
-          ### 🌐 Chrome / Brave / Edge (Developer Mode - Manual updates)
-          **Download:** `saveit-chrome-${{ steps.get_version.outputs.VERSION }}.zip` ⚠️ Unsigned (for testing/sideloading)
+          ### 🌐 Chrome / Brave / Edge (Web Store - Auto-updates)
+          Install from the Chrome Web Store (auto-updates enabled):
+          **[Install from Chrome Web Store →](https://chromewebstore.google.com/)**
 
-          **Installation:**
-          1. Download and **extract** the `.zip` file
-          2. Open your browser's extensions page:
-             - Chrome: `chrome://extensions`
-             - Brave: `brave://extensions`
-             - Edge: `edge://extensions`
-          3. Enable **"Developer mode"** (toggle in top right)
-          4. Click **"Load unpacked"**
-          5. Select the **extracted folder** (the folder containing `manifest.json`)
+          This version is published to the Chrome Web Store as part of this release and is
+          submitted for review. Once approved it auto-updates for all Chrome users.
 
-          **Note:** Chrome builds are unsigned and require developer mode. You'll need to manually download and install new versions when they're released.
+          For sideloading/testing, download the unsigned zip below and load it unpacked.
 
           ---
           EOF
@@ -199,3 +193,68 @@ jobs:
           git add updates.json
           HUSKY=0 git commit --no-verify -m "Update updates.json for v$VERSION [skip ci]"
           git push origin main
+
+  # Publish to the Chrome Web Store on every tag. Runs after the Firefox/GitHub
+  # release job so a signing failure there doesn't burn a Chrome review slot.
+  # Uploads AND auto-publishes (submits for review). If the listing is missing
+  # required Developer Dashboard info (e.g. Privacy practices), publish fails —
+  # fix that once in the dashboard at:
+  #   https://chrome.google.com/webstore/devconsole
+  upload-chrome:
+    needs: release
+    runs-on: ubuntu-latest
+    name: Publish to Chrome Web Store
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build bundles
+        run: node scripts/bundle-firebase.js
+
+      - name: Build Chrome extension
+        run: npm run build:chrome
+
+      - name: Get version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Verify Chrome ZIP exists
+        run: |
+          ZIP_FILE="web-ext-artifacts/saveit-chrome-${{ steps.get_version.outputs.VERSION }}.zip"
+          if [ ! -f "$ZIP_FILE" ]; then
+            echo "❌ Chrome ZIP not found: $ZIP_FILE"
+            exit 1
+          fi
+          echo "✅ Found: $ZIP_FILE"
+
+      - name: Upload and publish to Chrome Web Store
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+        run: node scripts/upload-chrome.js --publish --target default
+
+      - name: Summary
+        run: |
+          echo "### 🌐 Chrome Web Store Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ steps.get_version.outputs.VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Submitted for review (typically 1-3 days)." >> $GITHUB_STEP_SUMMARY
+          echo "Check status: https://chrome.google.com/webstore/devconsole" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## What

Adds an `upload-chrome` job to `release.yml` so every tag release (`git push --tags`) publishes to the Chrome Web Store automatically, matching the existing Firefox/AMO flow.

- Runs **after** the `release` job (`needs: release`) so a Firefox signing failure doesn't burn a Chrome review slot
- Builds the Chrome zip, uploads via `scripts/upload-chrome.js`, and **auto-publishes** (`--publish --target default` → submitted for review)
- Updates the GitHub Release notes: Chrome section now points to the Web Store instead of "developer mode sideloading"
- Keeps the standalone `upload-chrome.yml` (`workflow_dispatch`) for ad-hoc re-runs

## ⚠️ Prerequisite for publish to succeed

The 2026-07-04 `upload-chrome` run failed with:

> To publish your item, you must provide mandatory privacy information in the new Developer Dashboard

Auto-publish will keep failing until the listing's **Privacy practices** tab is filled in **once**, at:
→ https://chrome.google.com/webstore/devconsole

Upload itself works regardless (proven by the 2026-07-02 success); only `--publish` is blocked by the missing privacy info.

## Validation
- YAML validated (2 jobs, `upload-chrome` needs `release`, concurrency group intact)
- No code change — workflow-only

## After merge
- For v1.18.0 (already released): Chrome wasn't published because this job didn't exist yet. After merge, either re-tag or run the manual `upload-chrome.yml` to get 1.18.0 onto the store. Going forward, every `just bump` + tag push publishes Chrome automatically.

🤖 Generated with [Claude Code](#)