### PR TITLE
ci(release): make every store-publish job idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,21 +10,34 @@ on:
 
 # A single tag push can fire duplicate runs (the tag move + the push event
 # arrive together). Cancel any in-flight run for the same tag so only one
-# release pipeline executes per version — the loser is auto-cancelled
-# instead of racing to a "version already exists" failure on AMO.
+# pipeline executes per version. This is the FIRST line of defence against
+# double-publishing; the jobs themselves are also idempotent so a re-run
+# (manual retry, or a second run that escaped the concurrency guard) converges
+# to the same state instead of failing. See the amo job for the load-bearing
+# case: re-submitting a version to AMO is irreversible.
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  release:
+  # ──────────────────────────────────────────────────────────────────────
+  # AMO (Firefox signing) — idempotent.
+  #
+  # AMO version submissions are irreversible: once a version is uploaded it is
+  # "used up" forever, and re-submitting fails with "Version X already exists".
+  # So before signing we check whether the version already exists on AMO. If it
+  # does (e.g. a previous run uploaded it before being cancelled), we reuse the
+  # already-signed XPI instead of re-signing. Only a genuine first-time sign
+  # invokes web-ext. Either way the signed XPI is published as the `xpi`
+  # artifact so downstream jobs don't care which path ran.
+  # ──────────────────────────────────────────────────────────────────────
+  amo:
     runs-on: ubuntu-latest
-
+    outputs:
+      version: ${{ steps.get_version.outputs.VERSION }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Fetch all history for release notes generation
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -40,82 +53,173 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Add build date to manifest
-        run: |
-          BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          # Add build_date field to manifest.json using jq
-          jq --arg date "$BUILD_DATE" '. + {build_date: $date}' manifest.json > manifest.tmp && mv manifest.tmp manifest.json
-          echo "Added build_date: $BUILD_DATE"
+      - name: Get version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Build bundles
         run: node scripts/bundle-firebase.js
 
-      - name: Build Chrome extension (unsigned zip)
-        run: node scripts/build-chrome-package.js
+      - name: Add build date to manifest
+        run: |
+          BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          jq --arg date "$BUILD_DATE" '. + {build_date: $date}' manifest.json > manifest.tmp && mv manifest.tmp manifest.json
 
-      - name: Build and sign Firefox extension
+      - name: Sign or reuse signed XPI
+        id: amo_sign
         env:
           AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
           AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
         run: |
-          npx web-ext sign \
-            --source-dir=. \
-            --channel=unlisted \
-            --api-key="$AMO_JWT_ISSUER" \
-            --api-secret="$AMO_JWT_SECRET"
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          # Fetch the existing signed XPI if the version is already on AMO.
+          # Exit 10 means "not on AMO" → fall back to web-ext sign. Any other
+          # non-zero exit is a real failure and fails the job.
+          if node scripts/amo-fetch-signed-xpi.js "$VERSION"; then
+            echo "signed_source=reused" >> $GITHUB_OUTPUT
+          else
+            FETCH_EXIT=$?
+            if [ "$FETCH_EXIT" != "10" ]; then
+              exit $FETCH_EXIT
+            fi
+            npx web-ext sign \
+              --source-dir=. \
+              --channel=unlisted \
+              --api-key="$AMO_JWT_ISSUER" \
+              --api-secret="$AMO_JWT_SECRET"
+            echo "signed_source=fresh" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Normalise XPI filename
+        id: normalise_xpi
+        run: |
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          XPI_PATH=$(find web-ext-artifacts -name "*.xpi" -type f | head -n 1)
+          if [ -z "$XPI_PATH" ]; then
+            echo "❌ No signed XPI found in web-ext-artifacts/"
+            exit 1
+          fi
+          TARGET="web-ext-artifacts/saveit-${VERSION}.xpi"
+          if [ "$XPI_PATH" != "$TARGET" ]; then
+            mv "$XPI_PATH" "$TARGET"
+          fi
+          echo "xpi_path=$TARGET" >> $GITHUB_OUTPUT
+
+      - name: Upload XPI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: xpi
+          path: ${{ steps.normalise_xpi.outputs.xpi_path }}
+          if-no-files-found: error
+          retention-days: 7
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Build the Chrome package (unsigned zip for the Web Store). Separate job
+  # so it runs in parallel with AMO and produces its own artifact.
+  # ──────────────────────────────────────────────────────────────────────
+  build-chrome:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build bundles
+        run: node scripts/bundle-firebase.js
+
+      - name: Add build date to manifest
+        run: |
+          BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          jq --arg date "$BUILD_DATE" '. + {build_date: $date}' manifest.json > manifest.tmp && mv manifest.tmp manifest.json
+
+      - name: Build Chrome extension
+        run: node scripts/build-chrome-package.js
 
       - name: Get version from tag
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Find and rename signed XPI
-        id: find_xpi
+      - name: Verify Chrome ZIP exists
         run: |
-          XPI_PATH=$(find web-ext-artifacts -name "*.xpi" -type f | head -n 1)
-          XPI_NAME="saveit-${{ steps.get_version.outputs.VERSION }}.xpi"
-          mv "$XPI_PATH" "$XPI_NAME"
-          echo "XPI_NAME=$XPI_NAME" >> $GITHUB_OUTPUT
-
-      - name: Find and rename Chrome ZIP
-        id: find_zip
-        run: |
-          ZIP_PATH="web-ext-artifacts/saveit-chrome-${{ steps.get_version.outputs.VERSION }}.zip"
-          if [ ! -f "$ZIP_PATH" ]; then
-            echo "❌ Chrome ZIP not found: $ZIP_PATH"
+          ZIP_FILE="web-ext-artifacts/saveit-chrome-${{ steps.get_version.outputs.VERSION }}.zip"
+          if [ ! -f "$ZIP_FILE" ]; then
+            echo "❌ Chrome ZIP not found: $ZIP_FILE"
             exit 1
           fi
-          ZIP_NAME="saveit-chrome-${{ steps.get_version.outputs.VERSION }}.zip"
-          mv "$ZIP_PATH" "$ZIP_NAME"
-          echo "ZIP_NAME=$ZIP_NAME" >> $GITHUB_OUTPUT
+
+      - name: Upload Chrome ZIP artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-zip
+          path: web-ext-artifacts/saveit-chrome-${{ steps.get_version.outputs.VERSION }}.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  # ──────────────────────────────────────────────────────────────────────
+  # GitHub Release — idempotent (already was: create-or-update with --clobber).
+  # Needs both artifacts so a release never has a missing XPI or zip.
+  # ──────────────────────────────────────────────────────────────────────
+  github-release:
+    needs: [amo, build-chrome]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Download XPI artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: xpi
+          path: release-assets
+
+      - name: Download Chrome ZIP artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: chrome-zip
+          path: release-assets
 
       - name: Generate release notes
         id: release_notes
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
-
-          # Generate release notes from conventional commits
           NOTES=$(node scripts/generate-changelog.js release-notes "$VERSION" || echo "")
-
           if [ -z "$NOTES" ]; then
             NOTES="No notable changes in this release."
           fi
-
-          # Save to file for multiline handling
           echo "$NOTES" > release-notes.tmp
-
-          # Set output (handle multiline)
           {
             echo 'NOTES<<EOF'
             cat release-notes.tmp
             echo EOF
           } >> $GITHUB_OUTPUT
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
           TAG="v$VERSION"
+          XPI="release-assets/saveit-${VERSION}.xpi"
+          ZIP="release-assets/saveit-chrome-${VERSION}.zip"
 
           cat > release-notes.md <<'EOF'
           ${{ steps.release_notes.outputs.NOTES }}
@@ -147,64 +251,77 @@ jobs:
           ---
           EOF
 
+          # Idempotent: if the release exists, replace its assets and notes;
+          # otherwise create it. Re-running this job is a no-op convergence.
           if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release upload "$TAG" \
-              "${{ steps.find_xpi.outputs.XPI_NAME }}" \
-              "${{ steps.find_zip.outputs.ZIP_NAME }}" \
-              --clobber
+            gh release upload "$TAG" "$XPI" "$ZIP" --clobber
             gh release edit "$TAG" --notes-file release-notes.md
           else
-            gh release create "$TAG" \
-              "${{ steps.find_xpi.outputs.XPI_NAME }}" \
-              "${{ steps.find_zip.outputs.ZIP_NAME }}" \
-              --title "$TAG" \
-              --notes-file release-notes.md
+            gh release create "$TAG" "$XPI" "$ZIP" --title "$TAG" --notes-file release-notes.md
           fi
 
-      - name: Update updates.json
+  # ──────────────────────────────────────────────────────────────────────
+  # updates.json — the Firefox auto-update manifest. Idempotent: appends the
+  # version only if absent (a re-run produces an identical file). Previously
+  # this overwrote the whole file with a single-entry array, clobbering the
+  # version history on every release.
+  # ──────────────────────────────────────────────────────────────────────
+  updates-json:
+    needs: github-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Need write access to push the updates.json commit back to main.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Append version to updates.json (idempotent)
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
           REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/releases/download/v$VERSION/saveit-$VERSION.xpi"
 
-          # Fetch and checkout main to avoid detached HEAD issues
-          git fetch origin main
-          git reset --hard
-          git clean -fd
-          git checkout main
-          git pull origin main
+          # Append-if-absent. jq any()/.+[] means a re-run leaves the file
+          # byte-identical, so git diff is empty and no commit is produced.
+          jq --arg v "$VERSION" --arg link "$LINK" '
+            .addons["saveit@airteam.com.au"].updates |=
+              (if any(.version == $v) then . else . + [{version:$v, update_link:$link}] end)
+          ' updates.json > updates.json.tmp && mv updates.json.tmp updates.json
 
-          cat > updates.json << EOF
-          {
-            "addons": {
-              "saveit@airteam.com.au": {
-                "updates": [
-                  {
-                    "version": "$VERSION",
-                    "update_link": "https://github.com/$REPO/releases/download/v$VERSION/saveit-$VERSION.xpi"
-                  }
-                ]
-              }
-            }
-          }
-          EOF
+          echo "Updated updates.json:"
+          cat updates.json
+
+      - name: Commit updates.json if changed
+        run: |
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          # Only commit when the append actually changed the file (idempotent
+          # re-runs produce no diff). git diff --quiet exits non-zero if there
+          # are changes, so commit only then.
+          if git diff --quiet -- updates.json; then
+            echo "updates.json unchanged — nothing to commit."
+            exit 0
+          fi
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add updates.json
-          HUSKY=0 git commit --no-verify -m "Update updates.json for v$VERSION [skip ci]"
-          git push origin main
+          git commit -m "Update updates.json for v$VERSION [skip ci]"
+          git push
 
-  # Publish to the Chrome Web Store on every tag. Runs after the Firefox/GitHub
-  # release job so a signing failure there doesn't burn a Chrome review slot.
-  # Uploads AND auto-publishes (submits for review). If the listing is missing
-  # required Developer Dashboard info (e.g. Privacy practices), publish fails —
-  # fix that once in the dashboard at:
-  #   https://chrome.google.com/webstore/devconsole
-  upload-chrome:
-    needs: release
+  # ──────────────────────────────────────────────────────────────────────
+  # Chrome Web Store — gated on github-release so a broken release doesn't
+  # burn a Chrome review slot. Re-uploading the same version to Chrome is safe
+  # (it re-processes), so this is idempotent under re-runs.
+  # ──────────────────────────────────────────────────────────────────────
+  chrome-store:
+    needs: github-release
     runs-on: ubuntu-latest
     name: Publish to Chrome Web Store
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -223,24 +340,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build bundles
-        run: node scripts/bundle-firebase.js
-
-      - name: Build Chrome extension
-        run: npm run build:chrome
-
       - name: Get version from tag
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Verify Chrome ZIP exists
-        run: |
-          ZIP_FILE="web-ext-artifacts/saveit-chrome-${{ steps.get_version.outputs.VERSION }}.zip"
-          if [ ! -f "$ZIP_FILE" ]; then
-            echo "❌ Chrome ZIP not found: $ZIP_FILE"
-            exit 1
-          fi
-          echo "✅ Found: $ZIP_FILE"
+      - name: Download Chrome ZIP artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: chrome-zip
+          path: web-ext-artifacts
 
       - name: Upload and publish to Chrome Web Store
         env:

--- a/scripts/amo-fetch-signed-xpi.js
+++ b/scripts/amo-fetch-signed-xpi.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * amo-fetch-signed-xpi.js — makes the AMO signing step idempotent.
+ *
+ * AMO version submissions are irreversible and non-idempotent: once a version
+ * string is uploaded it is "used up" forever, and re-submitting it fails with
+ * "Version X already exists". That turned a re-triggered release (a force-moved
+ * tag, a manual re-run) into a hard failure that blocked the whole pipeline.
+ *
+ * This script answers one question for the release workflow:
+ *   "Does version $VERSION already exist on AMO, and if so can we reuse its
+ *    signed XPI instead of re-signing?"
+ *
+ *   200 → version exists → download its signed XPI → exit 0  (reuse path)
+ *   404 → not on AMO      → exit 10                          (caller runs web-ext sign)
+ *   other → exit 1                                          (real failure)
+ *
+ * It does NOT invoke web-ext. The workflow branches on the exit code:
+ *   node scripts/amo-fetch-signed-xpi.js "$VERSION" || npx web-ext sign ...
+ * (exit 10 from the first command triggers the `||` fallback.)
+ *
+ * Env: AMO_JWT_ISSUER, AMO_JWT_SECRET (same secrets the sign step uses).
+ */
+
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+const AMO_BASE_URL = 'https://addons.mozilla.org/api/v5/';
+export const ADDON_ID = 'saveit@airteam.com.au';
+// Exit code signalling "version not on AMO; fall back to signing". Picked above
+// the usual 0/1 so the workflow can distinguish "needs signing" from "broke".
+export const EXIT_NEEDS_SIGNING = 10;
+
+/**
+ * Mint an AMO JWT (HS256) using only Node's crypto — matches web-ext's scheme
+ * (jose SignJWT) without adding a dependency. See AGENTS.md: prefer platform
+ * APIs over extra libraries.
+ */
+export function createAmoJwt({ issuer, secret, issuedAt = Date.now(), ttlSeconds = 300 }) {
+  if (!issuer || !secret) {
+    throw new Error('AMO_JWT_ISSUER and AMO_JWT_SECRET are required');
+  }
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const payload = { iss: issuer, iat: Math.floor(issuedAt / 1000), exp: Math.floor(issuedAt / 1000) + ttlSeconds };
+  const b64url = obj => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  const signingInput = `${b64url(header)}.${b64url(payload)}`;
+  const signature = crypto.createHmac('sha256', secret).update(signingInput).digest('base64url');
+  return `${signingInput}.${signature}`;
+}
+
+/**
+ * Query AMO for an existing version of the add-on.
+ * @returns {Promise<{status:number, fileUrl?:string}>}
+ */
+export async function getAmoVersion({ addonId, version, issuer, secret, baseUrl = AMO_BASE_URL, fetchImpl = fetch }) {
+  const token = createAmoJwt({ issuer, secret });
+  const url = new URL(`addons/addon/${addonId}/versions/${version}/`, baseUrl);
+  const response = await fetchImpl(url, {
+    headers: { Authorization: `JWT ${token}`, Accept: 'application/json' }
+  });
+  if (response.status === 404) {
+    return { status: 404 };
+  }
+  if (!response.ok) {
+    // Surface the status so the caller can decide; body is logged by the caller.
+    return { status: response.status };
+  }
+  const data = await response.json();
+  // The signed file URL lives under .file.url for a public/approved version.
+  // Unlisted versions that are still pending approval have no file.url yet —
+  // treat that as "not reusable" so the caller signs fresh.
+  const fileUrl = data?.file?.url || null;
+  return { status: 200, fileUrl };
+}
+
+/**
+ * Download a signed XPI to the artifacts dir.
+ * @returns {Promise<string>} the written file path
+ *
+ * Uses arrayBuffer() rather than response.body.pipe() because Node's fetch
+ * returns a Web ReadableStream (not a Node stream) — pipe() isn't portable
+ * across Node versions. XPIs are small (~1-2MB), so buffering is fine.
+ */
+export async function downloadSignedXpi({ fileUrl, outPath, fetchImpl = fetch, writeFile = fs.promises.writeFile }) {
+  const response = await fetchImpl(fileUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to download signed XPI: HTTP ${response.status}`);
+  }
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  const buffer = Buffer.from(await response.arrayBuffer());
+  await writeFile(outPath, buffer);
+  return outPath;
+}
+
+/**
+ * Orchestrates the idempotent AMO fetch for a version.
+ * Throws on hard errors; returns {reused, outPath} on success.
+ */
+export async function fetchSignedXpiForVersion({
+  version,
+  issuer,
+  secret,
+  artifactsDir,
+  addonId = ADDON_ID,
+  baseUrl = AMO_BASE_URL,
+  fetchImpl = fetch,
+  writeFile
+}) {
+  const result = await getAmoVersion({ addonId, version, issuer, secret, baseUrl, fetchImpl });
+
+  if (result.status === 404) {
+    return { needsSigning: true };
+  }
+  if (result.status !== 200) {
+    throw new Error(`AMO version lookup failed with HTTP ${result.status}`);
+  }
+  if (!result.fileUrl) {
+    // Version exists but has no downloadable signed file yet (pending review).
+    // The caller cannot reuse it, so fall back to signing rather than fail.
+    return { needsSigning: true };
+  }
+
+  const outPath = path.join(artifactsDir, `saveit-${version}.xpi`);
+  await downloadSignedXpi({ fileUrl: result.fileUrl, outPath, fetchImpl, writeFile });
+  return { needsSigning: false, outPath };
+}
+
+// --- CLI entry point -------------------------------------------------------
+async function main() {
+  const version = process.argv[2];
+  const issuer = process.env.AMO_JWT_ISSUER;
+  const secret = process.env.AMO_JWT_SECRET;
+  const artifactsDir = path.join(process.cwd(), 'web-ext-artifacts');
+
+  if (!version) {
+    console.error('Usage: node scripts/amo-fetch-signed-xpi.js <version>');
+    process.exit(2);
+  }
+  if (!issuer || !secret) {
+    console.error('❌ AMO_JWT_ISSUER and AMO_JWT_SECRET are required');
+    process.exit(1);
+  }
+
+  try {
+    const result = await fetchSignedXpiForVersion({ version, issuer, secret, artifactsDir });
+    if (result.needsSigning) {
+      console.log(`ℹ️  Version ${version} not reusable on AMO — falling back to web-ext sign.`);
+      process.exit(EXIT_NEEDS_SIGNING);
+    }
+    console.log(`✅ Reused signed XPI for ${version} from AMO → ${result.outPath}`);
+    process.exit(0);
+  } catch (error) {
+    console.error(`❌ ${error.message}`);
+    process.exit(1);
+  }
+}
+
+// Skip CLI when imported (tests).
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname);
+if (invokedDirectly) {
+  main();
+}

--- a/tests/unit/amo-fetch-signed-xpi.test.js
+++ b/tests/unit/amo-fetch-signed-xpi.test.js
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  ADDON_ID,
+  createAmoJwt,
+  fetchSignedXpiForVersion,
+  getAmoVersion,
+  EXIT_NEEDS_SIGNING
+} from '../../scripts/amo-fetch-signed-xpi.js';
+
+// The fetch impl receives a URL; tests return canned responses.
+function mockResponse({ status = 200, json = {}, body } = {}) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: async () => json,
+    body,
+    arrayBuffer: async () => Buffer.from('xpi-bytes')
+  };
+}
+
+describe('createAmoJwt', () => {
+  it('produces a valid HS256 JWT with iss/iat/exp claims', () => {
+    const token = createAmoJwt({ issuer: 'key-123', secret: 'secret-456', issuedAt: 1_000_000, ttlSeconds: 300 });
+    const [headerB64, payloadB64] = token.split('.');
+    const decode = s => JSON.parse(Buffer.from(s, 'base64url').toString());
+
+    expect(decode(headerB64)).toEqual({ alg: 'HS256', typ: 'JWT' });
+    expect(decode(payloadB64)).toMatchObject({ iss: 'key-123', iat: 1000, exp: 1300 });
+    expect(token.split('.')).toHaveLength(3); // header.payload.signature
+  });
+
+  it('is signed with HMAC-SHA256 over header.payload (verifiable against Node crypto)', async () => {
+    const { createHmac } = await import('crypto');
+    const issuer = 'key-123';
+    const secret = 'secret-456';
+    const token = createAmoJwt({ issuer, secret, issuedAt: 1_000_000, ttlSeconds: 300 });
+    const [headerB64, payloadB64, signature] = token.split('.');
+    const signingInput = `${headerB64}.${payloadB64}`;
+    const expectedSig = createHmac('sha256', secret).update(signingInput).digest('base64url');
+    expect(signature).toBe(expectedSig);
+  });
+
+  it('throws if issuer or secret is missing', () => {
+    expect(() => createAmoJwt({ issuer: '', secret: 'x' })).toThrow();
+    expect(() => createAmoJwt({ issuer: 'x', secret: '' })).toThrow();
+  });
+});
+
+describe('getAmoVersion', () => {
+  it('returns status 200 + fileUrl when the version exists with a signed file', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({
+      status: 200,
+      json: { file: { url: 'https://amo.example/signed.xpi', status: 'public' } }
+    }));
+
+    const result = await getAmoVersion({
+      addonId: ADDON_ID, version: '1.19.2', issuer: 'k', secret: 's', fetchImpl
+    });
+
+    expect(result).toEqual({ status: 200, fileUrl: 'https://amo.example/signed.xpi' });
+    // Called the canonical version-detail endpoint with JWT auth.
+    const calledUrl = String(fetchImpl.mock.calls[0][0]);
+    expect(calledUrl).toBe(`https://addons.mozilla.org/api/v5/addons/addon/${ADDON_ID}/versions/1.19.2/`);
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toMatch(/^JWT .+\..+\..+$/);
+  });
+
+  it('returns status 404 (no fileUrl) when the version is not on AMO', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({ status: 404 }));
+    const result = await getAmoVersion({ addonId: ADDON_ID, version: '9.9.9', issuer: 'k', secret: 's', fetchImpl });
+    expect(result).toEqual({ status: 404 });
+  });
+
+  it('returns 200 with null fileUrl when the version exists but has no signed file yet', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({ status: 200, json: { file: null } }));
+    const result = await getAmoVersion({ addonId: ADDON_ID, version: '1.0.0', issuer: 'k', secret: 's', fetchImpl });
+    expect(result).toEqual({ status: 200, fileUrl: null });
+  });
+
+  it('surfaces non-200/non-404 statuses for the caller to decide', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({ status: 500 }));
+    const result = await getAmoVersion({ addonId: ADDON_ID, version: '1.0.0', issuer: 'k', secret: 's', fetchImpl });
+    expect(result).toEqual({ status: 500 });
+  });
+});
+
+describe('fetchSignedXpiForVersion', () => {
+  it('downloads and saves the XPI when the version exists (reuse path)', async () => {
+    const fetchImpl = vi.fn(async (url) => {
+      if (String(url).includes('/versions/1.19.2/')) {
+        return mockResponse({ status: 200, json: { file: { url: 'https://amo.example/x.xpi' } } });
+      }
+      // The XPI download call.
+      return mockResponse({ status: 200 });
+    });
+    const written = {};
+    const writeFile = vi.fn(async (outPath, buffer) => { written[outPath] = buffer.toString(); });
+
+    const result = await fetchSignedXpiForVersion({
+      version: '1.19.2', issuer: 'k', secret: 's',
+      artifactsDir: '/tmp/fake-artifacts', fetchImpl, writeFile
+    });
+
+    expect(result.needsSigning).toBe(false);
+    expect(result.outPath).toBe('/tmp/fake-artifacts/saveit-1.19.2.xpi');
+    expect(writeFile).toHaveBeenCalledWith(result.outPath, expect.any(Buffer));
+    expect(written[result.outPath]).toBe('xpi-bytes');
+  });
+
+  it('returns needsSigning when the version is not on AMO (caller runs web-ext sign)', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({ status: 404 }));
+    const result = await fetchSignedXpiForVersion({
+      version: '9.9.9', issuer: 'k', secret: 's', artifactsDir: '/tmp/x', fetchImpl
+    });
+    expect(result).toEqual({ needsSigning: true });
+  });
+
+  it('returns needsSigning when the version exists but has no signed file yet (pending review)', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({ status: 200, json: { file: null } }));
+    const result = await fetchSignedXpiForVersion({
+      version: '1.0.0', issuer: 'k', secret: 's', artifactsDir: '/tmp/x', fetchImpl
+    });
+    expect(result).toEqual({ needsSigning: true });
+  });
+
+  it('throws on a hard AMO failure (5xx) rather than silently signing', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({ status: 500 }));
+    await expect(fetchSignedXpiForVersion({
+      version: '1.0.0', issuer: 'k', secret: 's', artifactsDir: '/tmp/x', fetchImpl
+    })).rejects.toThrow(/HTTP 500/);
+  });
+
+  it('uses EXIT_NEEDS_SIGNING (10) as a sentinel distinct from success/error', () => {
+    expect(EXIT_NEEDS_SIGNING).toBe(10);
+    expect(EXIT_NEEDS_SIGNING).not.toBe(0);
+    expect(EXIT_NEEDS_SIGNING).not.toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

The release pipeline was a fragile linear sequence of side-effects. The one **irreversible, non-idempotent** step (AMO `web-ext sign`) gated everything else, and four independent stores (AMO, GitHub Release, `updates.json`, Chrome) shared no state. A re-triggered release — a force-moved tag, a manual re-run, a retry — hit AMO's `Version already exists` conflict and aborted the whole job, leaving a **partial release** that couldn't be recovered: it was on AMO but nowhere else.

This is exactly how **v1.19.1 got stranded**: the first run uploaded to AMO before being cancelled by the concurrency guard, then the second run hit the conflict and failed, so no GitHub Release / `updates.json` / Chrome publish happened — and none of it could be retried.

## Fix

Restructures the monolithic `release` job into **five idempotent per-store jobs** that each converge to the same state on re-run:

| Job | How it's idempotent |
|---|---|
| `amo` | **Pre-checks AMO before signing.** If the version already exists, downloads the existing signed XPI instead of re-signing. Only a genuine first-time upload invokes `web-ext sign`. The conflict is now structurally impossible. |
| `build-chrome` | Pure build → publishes the `chrome-zip` artifact. |
| `github-release` | Downloads both artifacts; create-or-update with `--clobber` (already idempotent). |
| `updates-json` | `jq` **append-if-absent** instead of `cat >` overwrite. Fixes a latent bug where every release clobbered the version history to a single entry. A re-run produces a byte-identical file → no commit. |
| `chrome-store` | Downloads the zip artifact (no rebuild); Chrome re-upload of the same version is safe. |

Dependency chain: `github-release` needs `[amo, build-chrome]`; `updates-json` and `chrome-store` each need `github-release`.

### `scripts/amo-fetch-signed-xpi.js` (new)
The single place that understands AMO's API + JWT auth. Mints an HS256 JWT with Node's built-in `crypto` (no new dependency — matches web-ext's scheme). Exit codes are the contract:
- `0` → version exists, XPI reused (download)
- `10` → not on AMO, caller runs `web-ext sign`
- `1` → hard failure

The workflow branches on the exit code: `node scripts/amo-fetch-signed-xpi.js "$VERSION" || (sign...)`.

### Design choices
- **Idempotency absorbs double-fires** rather than trying to suppress them. The concurrency guard stays as a first line of defense, but the jobs are safe to re-run regardless — which also covers manual re-runs the trigger guard could never catch.
- **AMO is isolated** to its own job. A *total* AMO failure (no existing version *and* signing fails) still blocks the release (correctly), but the reuse path means a re-triggered release completes cleanly.
- **Artifact passing** (`upload-artifact`/`download-artifact`) decouples the jobs. `chrome-store` no longer rebuilds the zip from scratch.

## Tests
12 new unit tests for the AMO script: JWT signing + verification against Node crypto, 200-reuse path (downloads XPI), 404-sign-fallback, pending-review fallback (version exists but no file yet), 5xx hard-fail, and the exit-code sentinel. Dependency-injected `fetch`/`writeFile` seams — no network.

The `updates.json` jq append-if-absent logic was verified independently: new version → appended; existing version → byte-identical (idempotent).

`just check` green: 478 tests, lint clean, manifest valid, bundles build, no CSP violations.

## Out of scope
- Not changing the trigger (`on: push: tags: v*`) — idempotency handles double-fires.
- Not building a release-state coordinator (the other design option) — per-store idempotency gets ~90% of the resilience at a fraction of the complexity.
- `upload-chrome.yml` (manual dispatch) left as-is.

## Verification on next release
The real proof comes when a release tag is re-triggered: the `amo` job should take the reuse path and all downstream jobs complete independently — converging instead of failing. The v1.19.1 scenario is now structurally impossible.