### PR TITLE
chore(newtab): rename and reorder avatar dropdown items

### DIFF
--- a/src/newtab.html
+++ b/src/newtab.html
@@ -72,7 +72,13 @@
                   <polyline points="1 20 1 14 7 14"></polyline>
                   <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>
                 </svg>
-                Reload from server
+                Refresh cache
+              </button>
+              <button id="hero-mirror-toggle" class="dropdown-item" type="button" aria-pressed="false" title="Keep a SaveIt/ folder in your browser bookmarks in sync with your saved pages">
+                <svg class="dropdown-item-icon mirror-toggle-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+                </svg>
+                <span class="dropdown-item-label">Sync to browser</span>
               </button>
               <button id="hero-sharing-btn" class="dropdown-item" type="button" title="Review who can see each of your projects">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
@@ -83,12 +89,6 @@
                   <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"></line>
                 </svg>
                 Sharing
-              </button>
-              <button id="hero-mirror-toggle" class="dropdown-item" type="button" aria-pressed="false" title="Keep a SaveIt/ folder in your browser bookmarks in sync with your saved pages">
-                <svg class="dropdown-item-icon mirror-toggle-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-                </svg>
-                <span class="dropdown-item-label">Sync browser</span>
               </button>
               <div class="user-info">
                 <span id="hero-user-email" class="user-email"></span>

--- a/tests/unit/mirror-toggle.test.js
+++ b/tests/unit/mirror-toggle.test.js
@@ -11,7 +11,7 @@ function setup({ initialResponse } = {}) {
   document.body.innerHTML = `
     <button id="hero-mirror-toggle" aria-pressed="false">
       <svg class="dropdown-item-icon"></svg>
-      <span class="dropdown-item-label">Sync browser</span>
+      <span class="dropdown-item-label">Sync to browser</span>
     </button>
     <div id="user-dropdown" class="hidden"></div>
   `;


### PR DESCRIPTION
Presentation-only tweaks to the avatar dropdown menu:

- **"Sync browser" → "Sync to browser"**, moved above **Sharing**. "Sync to browser" reads as an action on the user's browser, and grouping it above Sharing keeps the sync/action items together.
- **"Reload from server" → "Refresh cache"** — clearer about what the action does (clears the local cache and reloads from the server).

The label text is static HTML; no code reads it programmatically (`initMirrorToggle` only flips `aria-pressed` and fires toasts). The `title` tooltip on Refresh cache still reads "Clear the local cache and reload everything from the server", which accurately describes the behaviour.

New dropdown order: Import bookmarks → Reload from server (Refresh cache) → Sync to browser → Sharing → user-info → Sign out.

No runtime behaviour change.