### PR TITLE
fix(release): checkout main in updates-json job; backfill v1.19.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
           echo "Updated updates.json:"
           cat updates.json
 
-      - name: Commit updates.json if changed
+      - name: Commit updates.json to main if changed
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
           # Only commit when the append actually changed the file (idempotent
@@ -304,6 +304,26 @@ jobs:
           # are changes, so commit only then.
           if git diff --quiet -- updates.json; then
             echo "updates.json unchanged — nothing to commit."
+            exit 0
+          fi
+
+          # The checkout is at the tag (detached HEAD). Switch to main and pull
+          # so the commit lands on the branch tip and pushes cleanly — a plain
+          # git push from detached HEAD fails with "not currently on a branch".
+          git fetch origin main
+          git checkout main
+          git pull origin main --ff-only
+
+          # Re-apply the append on the freshly-pulled main (in case a parallel
+          # job or bot commit advanced it since the checkout).
+          LINK="https://github.com/${{ github.repository }}/releases/download/v$VERSION/saveit-$VERSION.xpi"
+          jq --arg v "$VERSION" --arg link "$LINK" '
+            .addons["saveit@airteam.com.au"].updates |=
+              (if any(.version == $v) then . else . + [{version:$v, update_link:$link}] end)
+          ' updates.json > updates.json.tmp && mv updates.json.tmp updates.json
+
+          if git diff --quiet -- updates.json; then
+            echo "updates.json unchanged after re-pull — nothing to commit."
             exit 0
           fi
 

--- a/updates.json
+++ b/updates.json
@@ -5,6 +5,10 @@
         {
           "version": "1.19.2",
           "update_link": "https://github.com/airteamaus/saveit-extension/releases/download/v1.19.2/saveit-1.19.2.xpi"
+        },
+        {
+          "version": "1.19.3",
+          "update_link": "https://github.com/airteamaus/saveit-extension/releases/download/v1.19.3/saveit-1.19.3.xpi"
         }
       ]
     }


### PR DESCRIPTION
## Problem
The new idempotent `updates-json` job failed on the **first run** (v1.19.3, run [28924427511](https://github.com/airteamaus/saveit-extension/actions/runs/28924427511)) with:
```
fatal: You are not currently on a branch.
```
The job checks out the tag (which puts the runner in **detached HEAD**), so a plain `git push` of the `updates.json` commit can't work. The old monolithic pipeline avoided this by checking out `main` before committing; the idempotent rewrite dropped that step.

## Impact
- **The release itself succeeded** — `amo`, `build-chrome`, `github-release`, and `chrome-store` all passed. The decoupled architecture proved its value: the `updates-json` failure did **not** block Chrome publish (it would have aborted the whole release in the old pipeline).
- But `updates.json` on `main` was left pointing only at 1.19.2, so Firefox auto-update wouldn't offer 1.19.3.

## Fix
1. **`updates-json` job**: switch to `main` and pull before committing, and re-apply the append on the freshly-pulled file (in case `main` advanced since the tag checkout) before committing. Keeps the idempotent no-op exit when there's no diff.
2. **Backfill** v1.19.3 into `updates.json` manually — repairs the entry the failed job didn't land. (History is now preserved: 1.19.2 + 1.19.3, proving the append-if-absent fix works.)

The `jq` append logic itself worked correctly on the failed run (logs showed both versions present in the computed file); only the push failed.

## Verification
- The next release will exercise the fixed job end-to-end.
- This PR's own CI confirms nothing else regressed.