### PR TITLE
chore(manifest): drop unused host permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,9 +23,7 @@
     "identity"
   ],
   "host_permissions": [
-    "https://*.run.app/*",
-    "https://www.googleapis.com/*",
-    "https://*.firebaseapp.com/*"
+    "https://*.run.app/*"
   ],
   "background": {
     "scripts": [


### PR DESCRIPTION
## What

Drops two host permissions that the extension never actually uses:

- `https://www.googleapis.com/*` — vestigial. The Firebase auth SDK calls `identitytoolkit.googleapis.com` and `securetoken.googleapis.com`, which this grant doesn't even cover. It was granting access to every Google API under `www` (Drive, Calendar, etc.) for nothing.
- `https://*.firebaseapp.com/*` — only referenced as the `authDomain` config value; never fetched at runtime.

Keeps `https://*.run.app/*` (the Cloud Function host).

## Why

Reduces the permission surface for store review and for users. `www.googleapis.com` was the worst grant — both excessive *and* ineffective.

## Testing

- `just validate` — 0 errors.
- No test references the removed permissions (only a stale `authDomain` string in `tests/setup.js`, unrelated).

## Context

First step toward single-origin auth. Phase 1 (backend session tokens) and Phase 2 (extension session client) will follow in their respective repos to collapse `host_permissions` to a single Cloud Function origin.

No behavior change — this only narrows what the extension is *allowed* to request, not what it calls.