### PR TITLE
fix(telemetry): capture genuine page-surface errors to Sentry

### DIFF
--- a/src/api-core.js
+++ b/src/api-core.js
@@ -83,6 +83,7 @@ export function applyApiCore(API, dependencies = {}) {
         return userId;
       } catch (error) {
         console.error('[getLastKnownUserId] Failed to read cached auth bootstrap:', error);
+        window.SentryHelpers?.captureError(error, { context: 'get-last-known-user-id' });
         this._lastKnownUserId = null;
         return null;
       }
@@ -115,6 +116,7 @@ export function applyApiCore(API, dependencies = {}) {
         });
       } catch (error) {
         console.error('[setLastKnownUser] Failed to persist cached auth bootstrap:', error);
+        window.SentryHelpers?.captureError(error, { context: 'set-last-known-user' });
       }
     },
 
@@ -133,6 +135,7 @@ export function applyApiCore(API, dependencies = {}) {
         await storage.remove(this.LAST_KNOWN_USER_KEY);
       } catch (error) {
         console.error('[clearLastKnownUser] Failed to clear cached auth bootstrap:', error);
+        window.SentryHelpers?.captureError(error, { context: 'clear-last-known-user' });
       }
     },
 

--- a/src/cache-manager.js
+++ b/src/cache-manager.js
@@ -167,6 +167,7 @@ export class CacheManager {
       });
     } catch (error) {
       console.error('[getCachedPages] Failed to read cache:', error);
+      window.SentryHelpers?.captureError(error, { context: 'cache-get-cached-pages' });
       return createCacheReadResult('error', {
         error,
         reason: 'read-failed'
@@ -217,6 +218,7 @@ export class CacheManager {
       });
     } catch (error) {
       console.error('[setCachedPages] Failed to write cache:', error);
+      window.SentryHelpers?.captureError(error, { context: 'cache-set-cached-pages' });
     }
   }
 
@@ -247,6 +249,7 @@ export class CacheManager {
       debugLog('[invalidateCache] Cache invalidated for user:', userId, { scope });
     } catch (error) {
       console.error('[invalidateCache] Failed to invalidate cache:', error);
+      window.SentryHelpers?.captureError(error, { context: 'cache-invalidate' });
     }
   }
 
@@ -262,6 +265,7 @@ export class CacheManager {
       debugLog('[clearAllCache] All cache cleared');
     } catch (error) {
       console.error('[clearAllCache] Failed to clear cache:', error);
+      window.SentryHelpers?.captureError(error, { context: 'cache-clear-all' });
     }
   }
 
@@ -287,6 +291,7 @@ export class CacheManager {
       debugLog('[cleanupLegacyCache] Removed legacy global cache');
     } catch (error) {
       console.error('[cleanupLegacyCache] Failed to cleanup legacy cache:', error);
+      window.SentryHelpers?.captureError(error, { context: 'cache-cleanup-legacy' });
     }
   }
 }

--- a/src/newtab-auth.js
+++ b/src/newtab-auth.js
@@ -75,6 +75,7 @@ export function createNewtabAuthController({
       await AuthMenu.signOut(() => getBrowserRuntime());
     } catch (error) {
       console.error('[newtab] Sign out failed:', error);
+      windowObj.SentryHelpers?.captureError(error, { context: 'newtab-sign-out' });
     }
   }
 
@@ -88,6 +89,7 @@ export function createNewtabAuthController({
       await refreshFromSession();
     } catch (error) {
       console.error('Sign-in failed:', error);
+      windowObj.SentryHelpers?.captureError(error, { context: 'newtab-sign-in' });
       windowObj.alert(getUserFacingSignInErrorMessage(error));
     }
   }
@@ -105,6 +107,7 @@ export function createNewtabAuthController({
       }
     } catch (error) {
       console.error('[newtab] Failed to handle auth state change:', error);
+      windowObj.SentryHelpers?.captureError(error, { context: 'newtab-auth-state-change' });
     }
   }
 

--- a/src/newtab-shared.js
+++ b/src/newtab-shared.js
@@ -103,6 +103,7 @@ export function updateVersionIndicator(versionNumberEl) {
     }
   } catch (error) {
     console.error('[newtab] Failed to get version:', error);
+    window.SentryHelpers?.captureError(error, { context: 'newtab-get-version' });
     versionNumberEl.textContent = 'unknown';
   }
 }


### PR DESCRIPTION
## What

Several error paths on the page surface logged to `console.error` only and never reached Sentry. This wires them up so any genuine error is reported.

## The gaps (12 sites, 3 categories)

**Auth lifecycle** (`newtab-auth.js`) — runtime-messaging/OAuth-flow errors that don't pass through `_executeWithErrorHandling`:
- Sign-out failure (`handleSignOut`)
- Interactive sign-in failure (`handleSignIn`)
- Auth-state resolution failure (`handleResolvedAuthState`)

**Storage** (`api-core.js`, `cache-manager.js`) — `chrome.storage` read/write/remove failures for the auth bootstrap cache and the page cache. Not API calls, so never hit the api-core capture point:
- `getLastKnownUserId`, `setLastKnownUser`, `clearLastKnownUser`
- `getCachedPagesState`, `setCachedPages`, `invalidateCache`, `clearAllCache`, `cleanupLegacyCache`

**Runtime** (`newtab-shared.js`) — `getManifest()` failure in the version indicator.

Each now calls `window.SentryHelpers?.captureError(error, { context })` alongside the existing `console.error`, matching the established `api-core` pattern.

## What was intentionally NOT changed

The `console.error` calls in `newtab-drawer-data.js` and `project-manager-actions.js` were left alone. Those catch blocks wrap `api.*` calls whose errors are **already captured upstream** by `_executeWithErrorHandling` (which captures + re-throws). Adding capture there would double-report.

## Testing

- `just check` exits **0** — 0 validation errors, 489 tests pass.
- No behavioral change beyond the added telemetry calls.