### PR TITLE
fix(mirror): populate empty category and shared project folders

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -255,20 +255,30 @@ async function applySessionRotation(response) {
 }
 
 // Minimal API surface for the bookmark mirror. The full newtab facade isn't
-// loaded in the background; we expose just the three methods reconcile() needs,
+// loaded in the background; we expose just the methods reconcile() needs,
 // backed by the same authenticated fetch. Cursor pagination mirrors the
 // newtab path (limit + cursor until hasNextPage is false).
 const mirrorApi = {
-  async getSavedPages({ limit = 100, sort = 'newest', cursor } = {}) {
+  async getSavedPages({ limit = 100, sort = 'newest', cursor, projectId } = {}) {
     const params = { limit, sort };
     if (cursor) {
       params.cursor = cursor;
+    }
+    // projectId scopes the query to a single project. On the backend this
+    // routes to getThingsForProject, which for company-shared projects returns
+    // pages saved by other users in the same company domain — letting the
+    // mirror render colleagues' saves into shared project folders.
+    if (projectId) {
+      params.projectId = projectId;
     }
     return fetchBackgroundApi('', { params });
   },
   async getProjects() {
     const projects = await fetchBackgroundApi('/projects');
     return Array.isArray(projects) ? projects : [];
+  },
+  async getCurrentUserId() {
+    return await getSessionUserId();
   }
 };
 

--- a/src/bookmark-mirror.js
+++ b/src/bookmark-mirror.js
@@ -59,13 +59,32 @@ function topClassificationLabel(classifications, type) {
   return best?.label || null;
 }
 
-// The broad "domain" (folder-level) bucket label for a page: the AI 'general'
-// classification label, falling back to the sentinel "Other" key when the page
-// has no general classification (e.g. not yet enriched).
-function generalBucketLabel(page) {
-  const label = page?.primary_classification_label
-    || topClassificationLabel(page?.classifications, 'general');
-  return label || OTHER_DOMAIN_KEY;
+// The broad "domain" / folder-level bucket labels for a page. Mirrors the
+// user-aggregate semantics (shared/user-aggregates.js buildUserAggregate): a
+// page appears under EVERY one of its 'general' classifications, not just the
+// primary one. When the page has no general classification at all it falls
+// back to the sentinel "Other" key. Returns an array of general keys (labels
+// or OTHER_DOMAIN_KEY), de-duplicated, order-stable.
+//
+// primary_classification_label is included when present so a page whose
+// primary label was set by the enricher but whose classifications array also
+// carries it doesn't double-count; it just guarantees the primary label is
+// represented even if the array omitted it.
+function generalBucketLabels(page) {
+  const labels = new Set();
+  const classifications = Array.isArray(page?.classifications) ? page.classifications : [];
+  for (const c of classifications) {
+    if (c?.type === 'general' && c.label) {
+      labels.add(c.label);
+    }
+  }
+  if (page?.primary_classification_label) {
+    labels.add(page.primary_classification_label);
+  }
+  if (labels.size === 0) {
+    return [OTHER_DOMAIN_KEY];
+  }
+  return Array.from(labels);
 }
 
 // The sub-bucket label for a page within a >10 folder: the AI 'domain'
@@ -105,10 +124,11 @@ function generalKeyFromBucket(key) {
 
 // Build the desired-set map:
 //   { [saveItPageId]: { buckets: Array<bucketKey>, url, title, subLabels: { [bucketKey]: subLabel|null } } }
-// A page in N projects expands to N project buckets. Every page also gets one
-// domain bucket (its general classification, or "Other") — so a project page
-// appears in both its project folder AND its domain folder, mirroring the
-// sidebar's project + domain split. Each bucket entry becomes its own bookmark.
+// A page in N projects expands to N project buckets. A page also gets one
+// domain bucket per general classification label (or "Other" when it has
+// none) — so a project page appears in its project folder AND each of its
+// domain folders, mirroring the sidebar's project + category split. Each
+// bucket entry becomes its own bookmark.
 export function buildDesiredSet(pages) {
   const desired = {};
   for (const page of pages || []) {
@@ -125,10 +145,13 @@ export function buildDesiredSet(pages) {
       subLabels[key] = subBucketLabel(page);
     }
 
-    const gKey = generalBucketLabel(page);
-    const dKey = domainBucketKey(gKey);
-    buckets.push(dKey);
-    subLabels[dKey] = subBucketLabel(page);
+    // One domain bucket per general classification label (matching the user
+    // aggregate's per-category thing list), or a single Other bucket.
+    for (const gKey of generalBucketLabels(page)) {
+      const dKey = domainBucketKey(gKey);
+      buckets.push(dKey);
+      subLabels[dKey] = subBucketLabel(page);
+    }
 
     desired[page.id] = {
       buckets,
@@ -569,7 +592,9 @@ async function readFolderChildrenByFolderId(bookmarksApi, folderIds) {
 
 // Fetch the entire saved-page set, paging through cursors. Bypasses the
 // WarmCacheListStore (which is UI-windowed) — the mirror wants the whole set.
-async function fetchAllPages(api) {
+// When projectId is given, scopes to that project (used to pull cross-user
+// pages for shared company projects).
+async function fetchAllPages(api, { projectId } = {}) {
   const all = [];
   let cursor = null;
   do {
@@ -577,7 +602,8 @@ async function fetchAllPages(api) {
       limit: RECONCILE_PAGE_SIZE,
       sort: 'newest',
       cursor,
-      skipCache: true
+      skipCache: true,
+      ...(projectId ? { projectId } : {})
     });
     // Require the expected { pages, pagination } shape. Previously a non-
     // conforming response (e.g. a request that returned the wrong shape) was
@@ -742,6 +768,39 @@ export async function reconcile({
     typeof api.getProjects === 'function' ? api.getProjects() : []
   ]);
   const projects = Array.isArray(projectsResult) ? projectsResult : [];
+
+  // Shared (company) projects can contain pages saved by other users. Those
+  // pages don't appear in the user's own saved-page set above, so the shared
+  // project folder would be created but left empty. Fetch the project-scoped
+  // page set for each shared project the user doesn't own and merge them in.
+  // (Project-scoped queries route to getThingsForProject on the backend, which
+  // crosses user boundaries for company projects.)
+  const currentUserId = typeof api.getCurrentUserId === 'function'
+    ? await api.getCurrentUserId()
+    : null;
+  const sharedProjects = projects.filter(
+    (p) => p.visibility === 'company' && p.owner_user_id && p.owner_user_id !== currentUserId
+  );
+  if (sharedProjects.length > 0) {
+    const sharedPages = await Promise.all(
+      sharedProjects.map((p) => fetchAllPages(api, { projectId: p.id }).catch((error) => {
+        onWarn?.(`shared project fetch failed for ${p.id}: ${error?.message || error}`);
+        return [];
+      }))
+    );
+    // De-duplicate by page id: a page may appear both in the user's own set
+    // and in a shared project. buildDesiredSet keys by id, so later entries
+    // would overwrite earlier ones — keep the first (own) occurrence.
+    const seenIds = new Set(pages.map((p) => p.id));
+    for (const batch of sharedPages) {
+      for (const page of batch) {
+        if (page?.id && !seenIds.has(page.id)) {
+          seenIds.add(page.id);
+          pages.push(page);
+        }
+      }
+    }
+  }
 
   const desired = buildDesiredSet(pages);
   const bucketPlan = computeBucketPlan(desired);

--- a/tests/unit/bookmark-mirror.test.js
+++ b/tests/unit/bookmark-mirror.test.js
@@ -123,18 +123,21 @@ function createFakeStorage(initial = {}) {
 }
 
 // A fake API facade returning a fixed page/project set, paginating by limit.
-function createFakeApi({ pages = [], projects = [], freshness = null }) {
+function createFakeApi({ pages = [], projects = [], freshness = null, projectPages = {}, currentUserId = null }) {
   return {
-    async getSavedPages({ limit = 100, cursor } = {}) {
-      const startIndex = cursor ? pages.findIndex((p) => p.id === cursor) + 1 : 0;
-      const slice = pages.slice(startIndex, startIndex + limit);
-      const nextCursor = startIndex + slice.length < pages.length
+    async getSavedPages({ limit = 100, cursor, projectId } = {}) {
+      // When scoped to a project, serve from the projectPages map (simulates
+      // the backend's cross-user getThingsForProject for shared projects).
+      const source = projectId ? (projectPages[projectId] || []) : pages;
+      const startIndex = cursor ? source.findIndex((p) => p.id === cursor) + 1 : 0;
+      const slice = source.slice(startIndex, startIndex + limit);
+      const nextCursor = startIndex + slice.length < source.length
         ? slice[slice.length - 1]?.id || null
         : null;
       return {
         pages: slice,
         pagination: {
-          total: pages.length,
+          total: source.length,
           hasNextPage: nextCursor !== null,
           nextCursor
         },
@@ -142,6 +145,9 @@ function createFakeApi({ pages = [], projects = [], freshness = null }) {
       };
     },
     async getProjects() { return projects; },
+    ...(currentUserId !== null
+      ? { async getCurrentUserId() { return currentUserId; } }
+      : {}),
     ...(freshness !== null
       ? { async checkSavedPagesUpdates() { return freshness; } }
       : {})
@@ -264,6 +270,26 @@ describe('buildDesiredSet', () => {
       { id: 'ok', url: 'https://ok.com', title: 'OK' }
     ]);
     expect(Object.keys(desired)).toEqual(['ok']);
+  });
+
+  it('places a page under ALL its general classifications, matching the UI aggregate', () => {
+    // Regression: the UI sidebar builds its category list from the user
+    // aggregate, which counts EVERY general classification on a page. A page
+    // with general labels "Health and Medicine" AND "Science" appears under
+    // both categories in the UI. The mirror previously placed the page under
+    // only primary_classification_label (or the single highest-confidence
+    // general label), so the other folder was created but left empty.
+    const desired = buildDesiredSet([{
+      id: 'a', url: 'https://a.com', title: 'A',
+      classifications: [
+        { type: 'general', label: 'Health and Medicine', confidence: 0.9 },
+        { type: 'general', label: 'Science', confidence: 0.8 }
+      ]
+    }]);
+    expect(desired.a.buckets).toEqual(
+      expect.arrayContaining(['domain:Health and Medicine', 'domain:Science'])
+    );
+    expect(desired.a.buckets).toHaveLength(2);
   });
 });
 
@@ -1063,5 +1089,45 @@ describe('reconcile (end-to-end against fakes)', () => {
     expect(warns[0]).toContain('boom');
     // Second create still happened.
     expect(result.summary.creates).toBe(2);
+  });
+
+  it('fetches cross-user pages for shared company projects', async () => {
+    // The user owns one page (p-mine) in a shared project. A colleague owns
+    // another page (p-colleague) in the same project. Without the cross-user
+    // fetch, the colleague's page would never reach the mirror and the shared
+    // project folder would be empty.
+    const bookmarksApi = createFakeBookmarksApi([{
+      id: 'root', children: [{ id: 'toolbar', children: [] }]
+    }]);
+    const storage = createFakeStorage();
+    await setMirrorEnabled(storage, true);
+
+    const api = createFakeApi({
+      currentUserId: 'me',
+      pages: [
+        { id: 'p-mine', url: 'https://mine.com', title: 'Mine', project_ids: ['shared-proj'] }
+      ],
+      projects: [{
+        id: 'shared-proj',
+        name: 'Team Links',
+        visibility: 'company',
+        owner_user_id: 'coworker'
+      }],
+      projectPages: {
+        'shared-proj': [
+          { id: 'p-mine', url: 'https://mine.com', title: 'Mine', project_ids: ['shared-proj'] },
+          { id: 'p-colleague', url: 'https://theirs.com', title: 'Theirs', project_ids: ['shared-proj'] }
+        ]
+      }
+    });
+
+    const result = await reconcile({ bookmarksApi, api, storage });
+    expect(result.applied).toBe(true);
+
+    const state = await getMirrorState(storage);
+    // Both the user's own page AND the colleague's page landed in the project.
+    expect(Object.keys(state.ownership).sort()).toEqual(['p-colleague', 'p-mine']);
+    expect(state.ownership['p-colleague'][0].bucketKey).toBe('project:shared-proj');
+    expect(state.ownership['p-mine'].map((e) => e.bucketKey)).toContain('project:shared-proj');
   });
 });


### PR DESCRIPTION
## What

Fixes two divergences that left bookmark-mirror folders created but empty.

### 1. Category folders (e.g. "Health and Medicine" — has 3 pages, 0 in bookmarks)

**Root cause:** The UI sidebar and the mirror used *different rules* for category membership.

- **UI sidebar** reads a precomputed aggregate (`buildUserAggregate`) that places a page under **every** one of its `general` classifications.
- **Mirror** placed a page under only its `primary_classification_label` (or the single highest-confidence label).

So a page tagged `general: "Health and Medicine"` AND `general: "Science"` appeared under both in the UI but under only one in the mirror — the other folder was created but left empty.

**Fix:** `buildDesiredSet` now creates a domain bucket per general classification label, matching the aggregate.

### 2. Shared (company) project folders empty

**Root cause:** Different data sources with different user scoping.

- **UI project view** (`getThingsForProject`) queries **across all users** for company projects — you see colleagues' saves.
- **Mirror** fetched only the current user's pages (`getSavedPages` is `user_id`-scoped), so a shared project folder was created (because `getProjects` lists it) but no pages from teammates landed in it.

**Fix:** `reconcile` now fetches the project-scoped page set for each shared project the user doesn't own (`?projectId=X` → backend's cross-user `getThingsForProject`) and merges them in, de-duplicated by page id. The `mirrorApi` gains `getCurrentUserId` to identify which projects are shared-vs-owned.

## No backend change needed

Both fixes use existing backend capabilities:
- `classifications` already carries all general labels on each thing doc
- `?projectId=X` already routes to the cross-user `getThingsForProject`

## Testing

- Failing test for each case (now passing): multi-label category placement, cross-user shared-project fetch.
- Extended `createFakeApi` to support `projectId` scoping + `getCurrentUserId`.
- `just check` exits 0 — **491 tests pass.**