### PR TITLE
fix(deploy): deploy-staging must use numeric versions for Firefox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ cd /Users/rich/Code/saveit-backend && ./scripts/deploy-function.sh
 | Task | Command |
 |---|---|
 | Pre-deploy checks | `just pre-deploy` |
-| Deploy staging | `just deploy-staging VERSION` |
+| Deploy staging | `just deploy-staging` |
 | Deploy production | `just deploy-prod` |
 | Bump version and tag | `just bump [patch\|minor\|major]` |
 | Setup git hooks | `just setup-hooks` |

--- a/docs/QA-INFRASTRUCTURE.md
+++ b/docs/QA-INFRASTRUCTURE.md
@@ -190,14 +190,15 @@ git push origin main --tags
 ### Staging Release (Beta Testing)
 
 ```bash
-# Deploy beta version to staging environment
-just deploy-staging 0.14.0
+# Bump patch version, tag, and push to trigger a staging release.
+# Firefox manifest versions must be dot-separated numbers, so staging
+# deploys use a patch bump rather than a -beta pre-release suffix.
+just deploy-staging
 
-# Test with real backend for 24-48 hours
-# If stable, promote to production
+# Test with real backend for 24-48 hours.
+# If stable, promote to production:
 
-just bump minor
-git push origin main --tags
+just deploy-prod
 ```
 
 ## 📈 Quality Metrics

--- a/justfile
+++ b/justfile
@@ -152,13 +152,18 @@ setup-hooks:
 clear-cache:
     ./scripts/clear-firefox-cache.sh
 
-# Deploy to staging (beta version)
-deploy-staging version:
-    @echo "Deploying v{{version}}-beta.1 to staging..."
-    npm version {{version}}-beta.1
-    git push origin main --tags
+# Deploy to staging (bumps patch version, tags, and pushes to trigger release)
+#
+# Firefox manifest versions must be dot-separated numbers (e.g. 1.21.2) —
+# semver pre-release suffixes like -beta.1 are rejected (VERSION_FORMAT_INVALID).
+# So a staging deploy is just a patch bump, which bump-version.js applies to
+# both manifest.json and package.json, commits, updates the changelog, and tags.
+deploy-staging:
+    @echo "Bumping patch version for staging deploy..."
+    @node scripts/bump-version.js patch
+    @git push origin main --tags
     @echo "✅ Staging deployment triggered!"
-    @echo "Monitor: https://github.com/your-repo/actions"
+    @echo "Monitor: https://github.com/airteamaus/saveit-extension/actions"
 
 # Promote staging to production
 deploy-prod:


### PR DESCRIPTION
## Problem

`just deploy-staging VERSION` appended `-beta.1` to the version via `npm version`, which broke staging deploys in two ways:

1. **Firefox rejects the version format** — manifest versions must be dot-separated numbers; semver pre-release suffixes like `-beta.1` cause `VERSION_FORMAT_INVALID` in web-ext validation. This failed the AMO signing job.
2. **Version mismatch** — `npm version` only updates `package.json`, not `manifest.json`, so the pre-push hook (which requires they match) rejected the push. I hit both of these deploying v1.21.1 and had to work around them manually.

This was a pre-existing flaw — the recipe would have failed for any version, not just this one.

## Fix

Replaced the recipe with a patch bump via the existing `bump-version.js` script, which already handles dual-file sync, commit, changelog, and tagging. Staging deploys now produce a valid numeric `x.y.z` version that Firefox accepts. Usage changes from `just deploy-staging 1.21.0` to just `just deploy-staging`.

Also fixed the placeholder monitoring URL (`github.com/your-repo`) and updated `AGENTS.md` + `docs/QA-INFRASTRUCTURE.md` to reflect the new usage.