### PR TITLE
Guard el() helpers + enforce manifest host_permissions coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,24 @@ SaveIt is a browser extension for saving and enriching bookmarks. The main repo 
 | Mode | Protocol | Data source | Use case |
 |---|---|---|---|
 | Standalone | `file://` | Mock data | UI development |
-| Extension | `moz-extension://` | Cloud Functions | Real data and auth flows |
+| Extension | `moz-extension://` or `chrome-extension://` | Cloud Functions | Real data and auth flows |
 
-Mode detection is handled in `src/api.js`.
+Mode detection is handled in `src/api.js`. The config layer (`src/config.js`) detects dev/staging/production from the manifest version and protocol.
+
+### Backend overview
+
+The backend (`/Users/rich/Code/saveit-backend/`) is **6 Cloud Functions across 4 source dirs**, each with its own deploy script. This is a known friction point — see the architecture-improvement notes below.
+
+| Function | Source dir | Role |
+|---|---|---|
+| `saveit` | `cloud-function/` | HTTP API: save, bulk-import, read, delete, projects, auth |
+| `saveit-enrich` (controller) | `cloud-function-enrich/` | Finds unenriched events, creates Cloud Tasks |
+| `saveit-enrich-worker` | `cloud-function-enrich/` | Processes one event: fetch content, AI classify, write Firestore doc |
+| `saveit-realtime` | `cloud-function-realtime/` | SSE stream: fans Firestore changes to connected clients |
+| `saveit-realtime-trigger-things` | `cloud-function-realtime-trigger/` | Firestore onWrite → emits realtime event docs |
+| `saveit-realtime-trigger-projects` | `cloud-function-realtime-trigger/` | Firestore onWrite → emits realtime event docs |
+
+Key pipeline: `extension save → saveit (BigQuery save_events) → enrich controller (Cloud Tasks) → worker (fetch + AI) → Firestore things doc → realtime trigger → SSE → extension`.
 
 ### Local development setup
 
@@ -194,3 +209,21 @@ cd /Users/rich/Code/saveit-backend && ./scripts/deploy-function.sh
 - Keep OAuth scopes minimal.
 - Do not commit secrets or embed private credentials in the extension.
 - Treat client-side storage and cache as convenience layers, not security boundaries.
+- `manifest.json` `host_permissions` must list **every** Cloud Run origin the extension calls. The realtime SSE service (`saveit-realtime`) runs on a separate subdomain from the main API — both must be listed or the browser silently blocks the fetch. Adding a new backend service means adding its origin here.
+
+## Known architectural debt
+
+These friction points caused real debugging time during the Data & sync overhaul. They are candidates for a future architecture improvement pass:
+
+1. **Backend deployment has too many moving parts.** 6 Cloud Functions, 4 deploy scripts, and `just deploy-all` only covers 3 of the 6 functions (it omits both realtime services). The realtime deploys have no justfile target at all and must be run by hand. Each script copies `shared/` and `contracts/` into its function dir by hand, and two scripts additionally copy handler files from `cloud-function/` — an implicit cross-dir dependency.
+
+2. **Ingestion pipeline has confusing branching.** Two writers of `save_events` (save vs bulk-import) duplicate the trigger logic. Duplicate detection runs at two levels (worker `thingExists` vs core `checkDuplicateThing`) with different semantics around soft-deleted docs — the worker gate can short-circuit before the core's undelete logic runs. `source` dispatch is a binary `if (client) else (jina)` with no validation.
+
+3. **Auth responsibilities are not DRY.** `shared/auth-helpers.js` has three near-identical authenticate functions (`authenticateWithToken`, `authenticateControllerRequest`, `authenticateWorkerRequest`) that differ only in which header they accept. The `paths.js` bootstrap is manually duplicated across 3 directories.
+
+4. **No staging environment for the backend.** Every backend deploy goes straight to the production project. The extension has a real staging path; the backend does not.
+
+5. **Post-deploy verification is partial.** Only the enrich functions have a smoke test. The main API, realtime SSE, and Firestore triggers have no automated post-deploy check.
+
+6. **Version-drift detection covers half the fleet.** `check-deployed-versions.sh` only reports 3 of 6 functions.
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The browser extension behind **Buckley's Bookmarks**.
 
 **⚠️ BETA SOFTWARE** - This extension is in active development. Features may change and bugs may occur.
 
-Save web pages with AI-powered organization. Automatically extracts content, generates summaries, and creates semantic tags using AI classification. Features semantic search, hierarchical topic navigation, pinned and all-pages feeds, and project collections directly on the new tab.
+Save web pages with AI-powered organization. Automatically extracts content, generates summaries, and creates semantic tags using AI classification. Features semantic search, hierarchical topic navigation, pinned and all-pages feeds, project collections directly on the new tab, and a consolidated Data & sync screen for importing, exporting, and browser-bookmark sync.
 
 ## For Testers
 
@@ -18,13 +18,13 @@ Save web pages with AI-powered organization. Automatically extracts content, gen
 5. Select the downloaded `.xpi` file
 6. Click "Add" when prompted
 
-### Chrome Installation
+### Chrome / Brave Installation
 
 1. Download or clone this repository
-2. Open Chrome and go to `chrome://extensions/`
+2. Open Chrome or Brave and go to `chrome://extensions/`
 3. Enable "Developer mode" (toggle in top-right)
 4. Click "Load unpacked"
-5. Select the extension directory
+5. Select the **repo root** directory (where `manifest.json` lives, not `src/`)
 6. Extension will remain until manually removed
 
 ### Getting Started
@@ -35,6 +35,7 @@ Save web pages with AI-powered organization. Automatically extracts content, gen
 4. **Search & discover**: Use semantic search to find related content by topic
 5. **Navigate topics**: Browse hierarchical topic tags to explore your saved pages by category
 6. **Organize projects**: Create project collections from the new-tab sidebar, add pages to multiple projects, and share a project with your company domain when needed
+7. **Import & export**: Open the avatar menu → "Data & sync" to import bookmarks from a Raindrop CSV, browser bookmarks HTML, or a Buckley's JSON backup; export your data in any of those formats; or toggle browser-bookmark sync
 
 ### Known Limitations (Beta)
 

--- a/src/import-panel.js
+++ b/src/import-panel.js
@@ -48,7 +48,11 @@ export function createImportPanel({
     if (text != null) node.textContent = text;
     if (html != null) node.innerHTML = html;
     if (attrs) {
-      for (const [k, v] of Object.entries(attrs)) node.setAttribute(k, v);
+      // Skip null/undefined values: setAttribute stringifies null to "null",
+      // which for boolean attributes like 'disabled' would wrongly enable them.
+      for (const [k, v] of Object.entries(attrs)) {
+        if (v != null) node.setAttribute(k, v);
+      }
     }
     if (onClick) node.onclick = onClick;
     if (children) {

--- a/src/sharing-centre.js
+++ b/src/sharing-centre.js
@@ -48,7 +48,11 @@ export function createSharingCentre({
     if (className) node.className = className;
     if (text != null) node.textContent = text;
     if (attrs) {
-      for (const [key, value] of Object.entries(attrs)) node.setAttribute(key, value);
+      // Skip null/undefined values: setAttribute stringifies null to "null",
+      // which for boolean attributes like 'disabled' would wrongly enable them.
+      for (const [key, value] of Object.entries(attrs)) {
+        if (value != null) node.setAttribute(key, value);
+      }
     }
     if (onClick) node.onclick = onClick;
     if (children) node.append(...children);

--- a/tests/unit/manifest-host-permissions.test.js
+++ b/tests/unit/manifest-host-permissions.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const configPath = resolve(repoRoot, 'src', 'config.js');
+const manifestPath = resolve(repoRoot, 'manifest.json');
+
+// Extract every backend host the extension can call from src/config.js.
+// We parse the source statically (rather than importing CONFIG) because CONFIG
+// only exposes the *active* environment, and this check must cover ALL of them
+// — a host added to staging/production must be in host_permissions regardless
+// of which environment the test process happens to detect.
+function backendHostsFromConfig() {
+  const src = readFileSync(configPath, 'utf8');
+  const hosts = new Set();
+  // Match https://... cloudFunctionUrl / realtimeFunctionUrl assignments across
+  // all environment blocks. Localhost (development) is intentionally excluded
+  // — it needs no host_permission.
+  const hostRe = /(cloudFunctionUrl|realtimeFunctionUrl):\s*'(https:\/\/[^']+)'/g;
+  let m;
+  while ((m = hostRe.exec(src)) !== null) {
+    hosts.add(m[2]);
+  }
+  return [...hosts].sort();
+}
+
+function hostPermissionsFromManifest() {
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  // Entries are match patterns like "https://host/*"; reduce to bare origins.
+  return manifest.host_permissions
+    .map((pattern) => pattern.replace(/\/\*$/, ''))
+    .sort();
+}
+
+describe('manifest host_permissions cover every configured backend host', () => {
+  it('lists every cloudFunctionUrl and realtimeFunctionUrl origin', () => {
+    const configured = backendHostsFromConfig();
+    const permitted = hostPermissionsFromManifest();
+
+    // Sanity: the config must actually contain some real hosts, otherwise the
+    // test would pass vacuously (e.g. if config.js were refactored to compute
+    // hosts differently and the regex silently matched nothing).
+    expect(configured.length).toBeGreaterThan(0);
+
+    const missing = configured.filter((host) => !permitted.includes(host));
+    if (missing.length > 0) {
+      throw new Error(
+        `Backend hosts configured in src/config.js but missing from manifest.json host_permissions.\n` +
+          `The browser silently blocks fetches to unlisted origins (this once broke every SSE connection).\n` +
+          `Missing:\n  ${missing.join('\n  ')}\n` +
+          `host_permissions has:\n  ${permitted.join('\n  ')}`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two safety fixes surfaced during the architecture cleanup pass (companion to airteamaus/saveit-backend#6).

### `fix: guard el() helpers against setAttribute(key, null)`
`setAttribute` stringifies `null` to `"null"`, which for boolean attributes like `disabled` wrongly enables them. `data-sync-centre.js` already guarded against this; `sharing-centre.js` and `import-panel.js` had the same unguarded loop. Adds the same `if (value != null)` check with an explanatory comment.

### `test: enforce every configured backend host is in manifest host_permissions`
A backend host added to `src/config.js` but missing from `manifest.json` `host_permissions` is silently blocked by the browser — this once broke every realtime SSE connection. The new test parses all `cloudFunctionUrl` / `realtimeFunctionUrl` origins from `config.js` and asserts each appears in `host_permissions`, so the drift can't recur silently.

**Mutation-tested:** removing the realtime host from the manifest fails the test with the exact historical bug named.

## Verification
`just check` → exit 0 (lint, CSS, prettier, web-ext validate all pass). Pre-commit hooks passed on both commits.