### PR TITLE
refactor: drawer architecture consolidation + cross-surface helper dedup

### DIFF
--- a/src/api-core.js
+++ b/src/api-core.js
@@ -36,6 +36,34 @@ export async function parseErrorResponse(response) {
   }
 }
 
+// Sliding session refresh: when the backend rotates a session token it returns
+// the replacement via response headers. Read the new token/expiry and persist
+// it. Shared by the API facade (_applySessionRotation below) and background.js's
+// lean fetch path. Best-effort: a failure here does not invalidate the request
+// that carried the rotation. The optional logger lets the background surface
+// rotation outcomes (the facade stays silent — the request already succeeded).
+export async function applySessionRotation(response, { logger } = {}) {
+  const headers = response.headers;
+  if (!headers || typeof headers.get !== 'function') {
+    return;
+  }
+  const newToken = headers.get('X-Session-Token');
+  const newExpiry = headers.get('X-Session-Expires-At');
+  if (!newToken || !newExpiry) {
+    return;
+  }
+  try {
+    const uid = await getSessionUserId();
+    if (uid) {
+      await setSession({ sessionToken: newToken, uid, expiresAt: newExpiry });
+      logger?.log?.('Session token rotated by backend');
+    }
+  } catch (error) {
+    // Non-fatal: the current request already succeeded.
+    logger?.warn?.('Failed to apply session rotation', { error: error.message });
+  }
+}
+
 export function applyApiCore(API, dependencies = {}) {
   const {
     cacheManagerClass = CacheManager,
@@ -291,23 +319,7 @@ export function applyApiCore(API, dependencies = {}) {
     },
 
     async _applySessionRotation(response) {
-      const headers = response.headers;
-      if (!headers || typeof headers.get !== 'function') {
-        return;
-      }
-      const newToken = headers.get('X-Session-Token');
-      const newExpiry = headers.get('X-Session-Expires-At');
-      if (!newToken || !newExpiry) {
-        return;
-      }
-      try {
-        const uid = await getSessionUserId();
-        if (uid) {
-          await setSession({ sessionToken: newToken, uid, expiresAt: newExpiry });
-        }
-      } catch {
-        // Non-fatal: the current request already succeeded.
-      }
+      await applySessionRotation(response);
     },
 
     async _fetchWithAuth(endpoint, params = null, options = {}) {

--- a/src/auth-menu.js
+++ b/src/auth-menu.js
@@ -105,7 +105,11 @@ const AuthMenu = {
       throw new Error('Browser runtime not available');
     }
 
-    const response = await runtime.sendMessage({ action: 'signIn' });
+    // Route through the shared sendRuntimeMessage helper (exposed as a global
+    // by config-loader.js) so the callback-vs-promise runtime shape is handled
+    // uniformly. Awaiting runtime.sendMessage directly only works once the
+    // polyfill has loaded; this resolves correctly even before that.
+    const response = await window.sendRuntimeMessage(runtime, { action: 'signIn' });
     if (response?.success === false) {
       throw new Error(response.error || 'Sign-in failed');
     }
@@ -121,7 +125,7 @@ const AuthMenu = {
       throw new Error('Browser runtime not available');
     }
 
-    const response = await runtime.sendMessage({ action: 'signOut' });
+    const response = await window.sendRuntimeMessage(runtime, { action: 'signOut' });
     if (response?.success === false) {
       throw new Error(response.error || 'Sign-out failed');
     }

--- a/src/background.js
+++ b/src/background.js
@@ -1,7 +1,7 @@
 // background.js - Service worker for the Buckley's extension (manifest v3)
 import { CONFIG } from './config.js';
 import { createBackgroundAuth } from './background-auth.js';
-import { getCurrentUserId as getSessionUserId, setSession } from './session-store.js';
+import { getCurrentUserId as getSessionUserId } from './session-store.js';
 import { CacheManager } from './cache-manager.js';
 import { ProjectsStore } from './projects-store.js';
 import { invalidateSavedPagesCacheStorage } from './saved-pages-cache.js';
@@ -10,7 +10,7 @@ import { getMirrorState, setMirrorEnabled } from './bookmark-mirror-settings.js'
 import { createLogger, getSafePageContext } from './telemetry.js';
 import { capturePageContent } from './page-capture-injector.js';
 import { addPendingSave } from './pending-saves.js';
-import { parseErrorResponse } from './api-core.js';
+import { applySessionRotation, parseErrorResponse } from './api-core.js';
 import { PROJECTS_CACHE_PREFIX, migrateProjectsCacheKeys } from './cache-keys.js';
 
 const logger = createLogger('background');
@@ -230,41 +230,13 @@ async function fetchBackgroundApi(path = '', { method = 'GET', body, params } = 
   // Sliding session refresh: the backend rotates the token inline once it
   // crosses the refresh threshold and returns the replacement here. Store it
   // so subsequent calls use the new token.
-  await applySessionRotation(response);
+  await applySessionRotation(response, { logger });
 
   if (response.status === 204) {
     return null;
   }
 
   return await response.json().catch(() => null);
-}
-
-// Update the stored session when the backend hands back a rotated token.
-// Best-effort: a failure here doesn't invalidate the current request.
-async function applySessionRotation(response) {
-  const headers = response.headers;
-  if (!headers || typeof headers.get !== 'function') {
-    return;
-  }
-  const newToken = headers.get('X-Session-Token');
-  const newExpiry = headers.get('X-Session-Expires-At');
-  if (!newToken || !newExpiry) {
-    return;
-  }
-  try {
-    const user = await getSessionUserId().then(async (uid) => {
-      if (uid) {
-        return { uid };
-      }
-      return null;
-    });
-    if (user?.uid) {
-      await setSession({ sessionToken: newToken, uid: user.uid, expiresAt: newExpiry });
-      logger.log('Session token rotated by backend');
-    }
-  } catch (error) {
-    logger.warn('Failed to apply session rotation', { error: error.message });
-  }
 }
 
 // Minimal API surface for the bookmark mirror. The full newtab facade isn't

--- a/src/config-loader.js
+++ b/src/config-loader.js
@@ -1,8 +1,11 @@
 // Load CONFIG and debug helpers, make them globally available
 import { CONFIG, debug, debugWarn, debugError, getBrowserRuntime, getStorageAPI } from './config.js';
+import { sendRuntimeMessage } from './send-runtime-message.js';
 window.CONFIG = CONFIG;
 window.debug = debug;
 window.debugWarn = debugWarn;
 window.debugError = debugError;
 window.getBrowserRuntime = getBrowserRuntime;
 window.getStorageAPI = getStorageAPI;
+// Exposed for non-module scripts (auth-menu.js) that can't use ES imports.
+window.sendRuntimeMessage = sendRuntimeMessage;

--- a/src/data-sync-centre.js
+++ b/src/data-sync-centre.js
@@ -23,6 +23,8 @@ import { readAllBookmarks } from './bookmark-reader.js';
 import { invalidateSavedPagesCacheStorage } from './saved-pages-cache.js';
 import { addPendingSaves } from './pending-saves.js';
 import { createDialogLifecycle } from './dialog-lifecycle.js';
+import { createEl, createQueryId } from './shared-ui-helpers.js';
+import { sendRuntimeMessage } from './send-runtime-message.js';
 import {
   parseRaindropCsv,
   parseNetscapeHtml,
@@ -39,13 +41,7 @@ export function createDataSyncCentre({
   notify = () => {},
   onImportComplete = () => {}
 } = {}) {
-  const queryId = (id) => {
-    try {
-      return documentObj?.getElementById?.(id) ?? null;
-    } catch {
-      return null;
-    }
-  };
+  const queryId = createQueryId(documentObj);
   const getBackdrop = () => queryId('data-sync-centre-backdrop');
   const getDialog = () => queryId('data-sync-centre-dialog');
 
@@ -65,24 +61,7 @@ export function createDataSyncCentre({
     }
   });
 
-  function el(tag, { className, text, html, attrs, onClick, children } = {}) {
-    const node = documentObj.createElement(tag);
-    if (className) node.className = className;
-    if (text != null) node.textContent = text;
-    if (html != null) node.innerHTML = html;
-    if (attrs) {
-      // Skip null/undefined values so callers can conditionally omit an
-      // attribute (e.g. disabled: busy ? 'disabled' : null). setAttribute
-      // stringifies null to "null", which for boolean attributes like
-      // 'disabled' would wrongly enable them.
-      for (const [k, v] of Object.entries(attrs)) {
-        if (v != null) node.setAttribute(k, v);
-      }
-    }
-    if (onClick) node.onclick = onClick;
-    if (children) node.append(...children);
-    return node;
-  }
+  const el = createEl(documentObj);
 
   // --- helpers -------------------------------------------------------------
 
@@ -366,26 +345,11 @@ export function createDataSyncCentre({
     ] });
   }
 
-  // Minimal runtime.sendMessage wrapper (Promise-based for both Firefox & Chrome).
+  // Thin wrapper over the shared sendRuntimeMessage helper so the call sites
+  // below can pass just the message. `runtime` is the injected factory param
+  // (the browser.runtime or chrome.runtime namespace).
   function sendRuntime(message) {
-    if (!runtime?.sendMessage) {
-      return Promise.reject(new Error('Browser runtime API not available'));
-    }
-    return new Promise((resolve, reject) => {
-      try {
-        const response = runtime.sendMessage(message, (res) => {
-          const lastError = runtime.lastError;
-          if (lastError) { reject(new Error(lastError.message)); return; }
-          resolve(res);
-        });
-        // Firefox returns a promise from sendMessage when no callback is given.
-        if (response && typeof response.then === 'function') {
-          response.then(resolve, reject);
-        }
-      } catch (error) {
-        reject(error);
-      }
-    });
+    return sendRuntimeMessage(runtime, message);
   }
 
   function render() {

--- a/src/import-panel.js
+++ b/src/import-panel.js
@@ -11,6 +11,7 @@
 import { readAllBookmarks } from './bookmark-reader.js';
 import { invalidateSavedPagesCacheStorage } from './saved-pages-cache.js';
 import { createDialogLifecycle } from './dialog-lifecycle.js';
+import { createEl, createQueryId } from './shared-ui-helpers.js';
 
 const STEP = { PREVIEW: 'preview', PROGRESS: 'progress', RESULT: 'result' };
 
@@ -22,13 +23,7 @@ export function createImportPanel({
 } = {}) {
   // Resolve the dialog elements lazily/tolerantly so the panel can be created
   // even when the document doesn't expose the elements (e.g. test harnesses).
-  const queryId = (id) => {
-    try {
-      return documentObj?.getElementById?.(id) ?? null;
-    } catch {
-      return null;
-    }
-  };
+  const queryId = createQueryId(documentObj);
   const getBackdrop = () => queryId('import-panel-backdrop');
   const getDialog = () => queryId('import-panel-dialog');
   let state = { step: STEP.PREVIEW, bookmarks: null, total: 0, skipped: 0, result: null, error: null };
@@ -42,25 +37,7 @@ export function createImportPanel({
     }
   });
 
-  function el(tag, { className, text, html, attrs, onClick, children } = {}) {
-    const node = documentObj.createElement(tag);
-    if (className) node.className = className;
-    if (text != null) node.textContent = text;
-    if (html != null) node.innerHTML = html;
-    if (attrs) {
-      // Skip null/undefined values: setAttribute stringifies null to "null",
-      // which for boolean attributes like 'disabled' would wrongly enable them.
-      for (const [k, v] of Object.entries(attrs)) {
-        if (v != null) node.setAttribute(k, v);
-      }
-    }
-    if (onClick) node.onclick = onClick;
-    if (children) {
-      // Append() returns undefined, so do it explicitly and return the node.
-      node.append(...children);
-    }
-    return node;
-  }
+  const el = createEl(documentObj);
 
   function renderPreview() {
     getDialog()?.replaceChildren(

--- a/src/newtab-app.js
+++ b/src/newtab-app.js
@@ -8,6 +8,7 @@ import { CONFIG } from './config.js';
 import { getSessionToken } from './session-store.js';
 import { RealtimeClient } from './realtime-client.js';
 import { RealtimeEventBus } from './realtime-event-bus.js';
+import { sendRuntimeMessage } from './send-runtime-message.js';
 import {
   createProjectsStore,
   createSavedPagesDrawerController,
@@ -194,17 +195,15 @@ export function createNewtabApp({
           // Clear the optimistic pending-save tile — replaces the enrichment poll.
           // The background SW owns pending-saves; relay via a runtime message.
           const browserApi = globalThis.browser ?? globalThis.chrome;
-          if (!browserApi?.runtime?.sendMessage) {
-            console.warn('[realtime] runtime.sendMessage unavailable; cannot relay enrichment event');
-            return;
-          }
           try {
-            await browserApi.runtime.sendMessage({
+            await sendRuntimeMessage(browserApi.runtime, {
               action: 'realtimePageEnriched',
               url: null,
               pageId: event.pageId
             });
           } catch (err) {
+            // Fire-and-forget relay: a failure here must never break the
+            // newtab page. The next refresh / realtime event recovers.
             console.warn('[realtime] failed to relay enrichment event:', err?.message || err);
           }
         }

--- a/src/newtab-drawer-controller.js
+++ b/src/newtab-drawer-controller.js
@@ -1,1 +1,0 @@
-export { createSavedPagesDrawerController } from './newtab-drawer-runtime.js';

--- a/src/newtab-drawer-data.js
+++ b/src/newtab-drawer-data.js
@@ -2,8 +2,25 @@ import { PINNED_PAGES_SCOPE_ID } from './project-manager-state.js';
 import { canHydrateDrawerWithWarmCache } from './newtab-drawer-coordination.js';
 import { createDomainSavedPagesStore, createProjectSavedPagesStore } from './newtab-drawer-stores.js';
 import {
-  INITIAL_RENDER_LIMIT,
-  RENDER_LIMIT_INCREMENT
+  beginDrawerWarming,
+  growDrawerRenderLimit,
+  nextDrawerRequestId,
+  nextDrawerSemanticRequestId,
+  resetDrawerRenderLimit,
+  setDrawerAllPages,
+  setDrawerDomains,
+  setDrawerEditingPage,
+  setDrawerInitialized,
+  setDrawerLoadedScopePages,
+  setDrawerLoading,
+  setDrawerProjects,
+  setDrawerProjectsAvailability,
+  setDrawerProjectsLoading,
+  setDrawerRenderedPages,
+  setDrawerSavingEdit,
+  setDrawerSemantic,
+  setDrawerView,
+  updateDrawerPageCollections
 } from './newtab-drawer-state.js';
 import { hasRenderableWarmCache, upsertListPages } from './warm-cache-list-store.js';
 
@@ -51,22 +68,14 @@ export function createDrawerDataController({
     return state.allPages.find(page => page.id === id) || null;
   }
 
-  function updateDrawerPageCollections(id, updater) {
-    state.allPages = state.allPages.map(page => (page.id === id ? updater(page) : page));
-    if (Array.isArray(state.loadedProjectPages)) {
-      state.loadedProjectPages = state.loadedProjectPages.map(page => (page.id === id ? updater(page) : page));
-    }
-    state.pages = state.pages.map(page => (page.id === id ? updater(page) : page));
-  }
-
   function syncProjectDrawerStateFromStore(projectId, snapshot, { query = state.query, render = state.hasInitialized } = {}) {
     if (!projectId || state.selectedProjectId !== projectId) {
       return;
     }
 
     const projectPages = snapshot?.allPages || [];
-    state.allPages = upsertListPages(state.allPages, projectPages, Number.POSITIVE_INFINITY);
-    state.loadedProjectPages = projectPages;
+    setDrawerAllPages(state, upsertListPages(state.allPages, projectPages, Number.POSITIVE_INFINITY));
+    setDrawerLoadedScopePages(state, projectPages);
     projectManager.refreshProjectCounts(savedPagesView);
     applyDrawerFilters(query);
 
@@ -105,8 +114,8 @@ export function createDrawerDataController({
     }
 
     const domainPages = snapshot?.allPages || [];
-    state.allPages = upsertListPages(state.allPages, domainPages, Number.POSITIVE_INFINITY);
-    state.loadedProjectPages = domainPages;
+    setDrawerAllPages(state, upsertListPages(state.allPages, domainPages, Number.POSITIVE_INFINITY));
+    setDrawerLoadedScopePages(state, domainPages);
     applyDrawerFilters(query);
 
     if (render) {
@@ -166,7 +175,7 @@ export function createDrawerDataController({
     }
 
     if (!drawerProjectsPromise) {
-      state.projectsLoading = true;
+      setDrawerProjectsLoading(state, true);
       drawerProjectsPromise = projectsStore
         .hydrate()
         .then(snapshot => {
@@ -176,17 +185,15 @@ export function createDrawerDataController({
         })
         .catch(error => {
           console.error('Failed to load projects:', error);
-          state.projects = [];
+          setDrawerProjects(state, []);
           if (error?.code === 'PROJECTS_UNSUPPORTED') {
-            state.projectsAvailable = false;
-            state.projectsUnavailableMessage = error.message;
+            setDrawerProjectsAvailability(state, { available: false, message: error.message });
           } else {
-            state.projectsAvailable = true;
-            state.projectsUnavailableMessage = '';
+            setDrawerProjectsAvailability(state, { available: true, message: '' });
           }
         })
         .finally(() => {
-          state.projectsLoading = false;
+          setDrawerProjectsLoading(state, false);
           drawerProjectsPromise = null;
         });
     }
@@ -194,11 +201,94 @@ export function createDrawerDataController({
     return drawerProjectsPromise;
   }
 
-  async function loadDrawerBasePages({ query = state.query, syncUrl = true } = {}) {
-    const requestId = ++state.requestId;
+  // --- Scope loading --------------------------------------------------------
+  // loadDrawerBasePages / loadDrawerProjectPages / loadDrawerDomainPages were
+  // three ~75-line copies of the same algorithm (requestId guard, sign-in gate,
+  // pre-hydrate UI arming, hydrate, sync, side-loads). They had drifted in
+  // message strings, the warming branch (all-only), and which side-loads ran.
+  // loadDrawerScope below is the single implementation; the three public names
+  // are thin wrappers that build a scope config and delegate.
+
+  function allPagesScope() {
+    return {
+      type: 'all',
+      // The all-pages store is the shared savedPagesStore; getStore returns it
+      // directly (not a memoized lookup), and reset() of the same store twice
+      // in the sign-in gate is harmless.
+      getStore: () => savedPagesStore,
+      syncFromStore: (snapshot, opts) => syncDrawerStateFromStore(snapshot, opts),
+      messages: {
+        searching: 'Searching your saved pages…',
+        gathering: 'Gathering your saved pages…',
+        failed: 'Could not reach your saved pages.',
+        logTag: '[newtab] Drawer load failed:'
+      },
+      // Only the all-pages store has the lazy flag and the warming subscriber
+      // path, so only this scope arms the warming pane.
+      armWarming: true,
+      loadProjectsAlongside: true,
+      loadDomainsAlongside: true,
+      // The all-pages caller (loadDrawerResults) owns the render window reset;
+      // scoped loaders reset their own.
+      resetRenderLimitFirst: false
+    };
+  }
+
+  function projectScope(projectId) {
+    return {
+      type: 'project',
+      id: projectId,
+      getStore: () => getProjectSavedPagesStore(projectId),
+      syncFromStore: (snapshot, opts) => syncProjectDrawerStateFromStore(projectId, snapshot, opts),
+      messages: {
+        searching: 'Searching project pages…',
+        gathering: 'Gathering project pages…',
+        failed: 'Could not reach your project pages.',
+        logTag: '[newtab] Project drawer load failed:'
+      },
+      armWarming: false,
+      loadProjectsAlongside: true,
+      loadDomainsAlongside: false,
+      resetRenderLimitFirst: true
+    };
+  }
+
+  function domainScope(domain) {
+    return {
+      type: 'domain',
+      id: domain,
+      getStore: () => getDomainSavedPagesStore(domain),
+      syncFromStore: (snapshot, opts) => syncDomainDrawerStateFromStore(domain, snapshot, opts),
+      messages: {
+        searching: 'Searching pages from this domain…',
+        gathering: 'Gathering pages from this domain…',
+        failed: 'Could not reach pages from this domain.',
+        logTag: '[newtab] Domain drawer load failed:'
+      },
+      armWarming: false,
+      // Domain view is a flat list; projects and further domain discovery are
+      // not relevant while browsing one domain's pages.
+      loadProjectsAlongside: false,
+      loadDomainsAlongside: false,
+      resetRenderLimitFirst: true
+    };
+  }
+
+  async function loadDrawerScope(scope, { query = state.query, syncUrl = true } = {}) {
+    if (scope.resetRenderLimitFirst) {
+      resetRenderLimit();
+    }
+    // Selecting a domain scope leaves the sparse home view for the browse list.
+    // (all-pages sets this via loadDrawerResults; project scope is entered from
+    // elsewhere that has already settled the view.)
+    if (scope.type === 'domain') {
+      setDrawerView(state, 'browse');
+    }
+
+    const requestId = nextDrawerRequestId(state);
     const trimmedQuery = query.trim();
 
-    state.isLoading = true;
+    setDrawerLoading(state, true);
     setDrawerSearchValue(trimmedQuery);
 
     if (syncUrl && isDrawerOpen()) {
@@ -206,41 +296,47 @@ export function createDrawerDataController({
     }
 
     if (!(await canHydrateDrawerWithWarmCache(api, getCurrentUser))) {
-      state.isLoading = false;
-      state.hasInitialized = true;
+      setDrawerLoading(state, false);
+      setDrawerInitialized(state, true);
       savedPagesStore.reset({ emit: false });
-      state.allPages = [];
-      state.pages = [];
+      // Reset the scope's own store too (project/domain). For the all-pages
+      // scope this is the same store as above — a redundant reset, harmless.
+      scope.getStore()?.reset?.({ emit: false });
+      setDrawerAllPages(state, []);
+      // all-pages uses null (no scope overlay); scoped views use [] (empty
+      // scope set). Both clear to "no scope pages loaded".
+      setDrawerLoadedScopePages(state, scope.type === 'all' ? null : []);
+      setDrawerRenderedPages(state, []);
       renderDrawerSignInState();
       return;
     }
 
-    const savedPagesSnapshot = savedPagesStore.getSnapshot();
-    if (!savedPagesSnapshot.allPages.length && !hasRenderableWarmCache(savedPagesSnapshot)) {
-      // Post-login the store is in non-lazy prefetch mode (set by the
+    const store = scope.getStore();
+    const snapshot = store?.getSnapshot?.() || null;
+    if (store && !snapshot?.allPages?.length && !hasRenderableWarmCache(snapshot)) {
+      // Post-login the all-pages store is in non-lazy prefetch mode (set by the
       // interactive Sign-in button). Arm the warming phase on state so the
       // dispatcher renders the warming pane (not the bare dog, and not cards
-      // mid-warm-up). The subscriber takes over progress updates once the
-      // first batch lands.
-      if (savedPagesStore.options.lazy === false) {
-        state.warmUpInProgress = true;
-        state.warmUpProgress = { percent: 0, indeterminate: true };
+      // mid-warm-up). The subscriber takes over progress updates once the first
+      // batch lands. Scoped views (project/domain) don't have this path.
+      if (scope.armWarming && store.options?.lazy === false) {
+        beginDrawerWarming(state, { percent: 0, indeterminate: true });
         renderDrawerResults();
       } else {
-        renderDrawerLoadingState(trimmedQuery ? 'Searching your saved pages…' : 'Gathering your saved pages…');
+        renderDrawerLoadingState(trimmedQuery ? scope.messages.searching : scope.messages.gathering);
       }
     }
 
     try {
-      const projectsPromise = ensureDrawerProjectsLoaded();
-      const snapshot = await savedPagesStore.hydrate();
+      const projectsPromise = scope.loadProjectsAlongside ? ensureDrawerProjectsLoaded() : null;
+      const fresh = await store.hydrate();
 
       if (requestId !== state.requestId) {
         return;
       }
 
-      syncDrawerStateFromStore(snapshot, { query: trimmedQuery, render: false });
-      state.hasInitialized = true;
+      scope.syncFromStore(fresh, { query: trimmedQuery, render: false });
+      setDrawerInitialized(state, true);
       renderDrawerResults();
 
       if (projectsPromise) {
@@ -254,103 +350,65 @@ export function createDrawerDataController({
         });
       }
 
-      // Load domains for the sidebar section alongside projects (non-blocking).
-      void ensureDrawerDomainsLoaded().then(() => {
-        if (requestId !== state.requestId) {
-          return;
-        }
-        renderDrawerResults();
-      });
+      // Load domains for the sidebar section alongside the all-pages view
+      // (non-blocking). Scoped views don't surface the domain list.
+      if (scope.loadDomainsAlongside) {
+        void ensureDrawerDomainsLoaded().then(() => {
+          if (requestId !== state.requestId) {
+            return;
+          }
+          renderDrawerResults();
+        });
+      }
     } catch (error) {
       if (requestId !== state.requestId) {
         return;
       }
 
-      console.error('[newtab] Drawer load failed:', error);
-      renderDrawerErrorState(error.message || 'Could not reach your saved pages.');
+      console.error(scope.messages.logTag, error);
+      renderDrawerErrorState(error.message || scope.messages.failed);
     } finally {
       if (requestId === state.requestId) {
-        state.isLoading = false;
+        setDrawerLoading(state, false);
       }
     }
   }
 
-  async function loadDrawerProjectPages(projectId, { query = state.query, syncUrl = true } = {}) {
+  async function loadDrawerBasePages(options) {
+    return loadDrawerScope(allPagesScope(), options);
+  }
+
+  async function loadDrawerProjectPages(projectId, options) {
+    // Pinned-pages sentinel and a null/empty id both route to the all-pages
+    // view — that's the "All pages" pseudo-scope.
     if (!projectId || projectId === PINNED_PAGES_SCOPE_ID) {
-      await loadDrawerBasePages({ query, syncUrl });
-      return;
+      return loadDrawerBasePages(options);
     }
+    return loadDrawerScope(projectScope(projectId), options);
+  }
 
-    const requestId = ++state.requestId;
-    const trimmedQuery = query.trim();
-    resetRenderLimit();
-
-    state.isLoading = true;
-    setDrawerSearchValue(trimmedQuery);
-
-    if (syncUrl && isDrawerOpen()) {
-      updateDrawerUrl(true, trimmedQuery);
+  // Pick the scope that matches the currently-selected project/domain so callers
+  // (forceReload) don't have to replicate the project-vs-domain-vs-all branch.
+  // Returns null when no scope is selected and the drawer hasn't initialized —
+  // callers should fall back to loadDrawerBasePages in that case.
+  function scopeForCurrentSelection() {
+    if (state.selectedProjectId && state.selectedProjectId !== PINNED_PAGES_SCOPE_ID) {
+      return projectScope(state.selectedProjectId);
     }
-
-    if (!(await canHydrateDrawerWithWarmCache(api, getCurrentUser))) {
-      state.isLoading = false;
-      state.hasInitialized = true;
-      savedPagesStore.reset({ emit: false });
-      getProjectSavedPagesStore(projectId)?.reset({ emit: false });
-      state.allPages = [];
-      state.loadedProjectPages = [];
-      state.pages = [];
-      renderDrawerSignInState();
-      return;
+    if (state.selectedDomainId) {
+      // selectedDomainId is stored WITH the "domain:" prefix (the nav-row
+      // convention), but the domain loaders receive the bare domain — strip
+      // it here so the scope id matches what the sync helper guards on.
+      const domain = state.selectedDomainId.startsWith('domain:')
+        ? state.selectedDomainId.slice('domain:'.length)
+        : state.selectedDomainId;
+      return domainScope(domain);
     }
+    return allPagesScope();
+  }
 
-    const projectSavedPagesStore = getProjectSavedPagesStore(projectId);
-    const projectSnapshot = projectSavedPagesStore?.getSnapshot?.() || null;
-    if (
-      projectSavedPagesStore &&
-      !projectSnapshot?.allPages?.length &&
-      !hasRenderableWarmCache(projectSnapshot)
-    ) {
-      renderDrawerLoadingState(trimmedQuery ? 'Searching project pages…' : 'Gathering project pages…');
-    }
-
-    try {
-      const projectsPromise = ensureDrawerProjectsLoaded();
-      const snapshot = await projectSavedPagesStore.hydrate();
-
-      if (requestId !== state.requestId) {
-        return;
-      }
-
-      syncProjectDrawerStateFromStore(projectId, snapshot, {
-        query: trimmedQuery,
-        render: false
-      });
-      state.hasInitialized = true;
-      renderDrawerResults();
-
-      if (projectsPromise) {
-        void projectsPromise.then(() => {
-          if (requestId !== state.requestId) {
-            return;
-          }
-
-          projectManager.refreshProjectCounts(savedPagesView);
-          renderDrawerResults();
-        });
-      }
-    } catch (error) {
-      if (requestId !== state.requestId) {
-        return;
-      }
-
-      console.error('[newtab] Project drawer load failed:', error);
-      renderDrawerErrorState(error.message || 'Could not reach your project pages.');
-    } finally {
-      if (requestId === state.requestId) {
-        state.isLoading = false;
-      }
-    }
+  async function loadDrawerScopeForCurrentSelection(options) {
+    return loadDrawerScope(scopeForCurrentSelection(), options);
   }
 
   async function handleDrawerDelete(id) {
@@ -383,7 +441,7 @@ export function createDrawerDataController({
       await savedPagesStore.removePage(id);
       await removeFromCachedProjectStores(id, deletedPage?.project_ids || []);
       if (Array.isArray(state.loadedProjectPages)) {
-        state.loadedProjectPages = state.loadedProjectPages.filter(page => page.id !== id);
+        setDrawerLoadedScopePages(state, state.loadedProjectPages.filter(page => page.id !== id));
       }
       syncDrawerStateFromStore(savedPagesStore.getSnapshot(), {
         query: state.query,
@@ -406,7 +464,7 @@ export function createDrawerDataController({
     }
 
     const nextPinnedState = !page.pinned;
-    updateDrawerPageCollections(id, entry => ({ ...entry, pinned: nextPinnedState }));
+    updateDrawerPageCollections(state, id, entry => ({ ...entry, pinned: nextPinnedState }));
     void savedPagesView.persistAllPages();
     void updateCachedProjectStores(page, entry => ({ ...entry, pinned: nextPinnedState }));
     renderDrawerResults();
@@ -414,7 +472,7 @@ export function createDrawerDataController({
     try {
       await api.pinPage(id, nextPinnedState);
     } catch (error) {
-      updateDrawerPageCollections(id, entry => ({ ...entry, pinned: !nextPinnedState }));
+      updateDrawerPageCollections(state, id, entry => ({ ...entry, pinned: !nextPinnedState }));
       void savedPagesView.persistAllPages();
       renderDrawerResults();
       console.error('[newtab] Failed to update pin:', error);
@@ -427,8 +485,8 @@ export function createDrawerDataController({
       return;
     }
 
-    state.editingPageId = id;
-    state.savingEditPageId = null;
+    setDrawerEditingPage(state, id);
+    setDrawerSavingEdit(state, null);
     renderDrawerResults();
   }
 
@@ -437,7 +495,7 @@ export function createDrawerDataController({
       return;
     }
 
-    state.editingPageId = null;
+    setDrawerEditingPage(state, null);
     renderDrawerResults();
   }
 
@@ -454,7 +512,7 @@ export function createDrawerDataController({
       return;
     }
 
-    state.savingEditPageId = id;
+    setDrawerSavingEdit(state, id);
     renderDrawerResults();
 
     try {
@@ -468,15 +526,15 @@ export function createDrawerDataController({
         title: nextTitle,
         ai_summary_brief: nextAiSummaryBrief
       });
-      updateDrawerPageCollections(id, applyResponseToPage);
-      state.editingPageId = null;
-      state.savingEditPageId = null;
+      updateDrawerPageCollections(state, id, applyResponseToPage);
+      setDrawerEditingPage(state, null);
+      setDrawerSavingEdit(state, null);
       await savedPagesView.persistAllPages();
       await updateCachedProjectStores(page, applyResponseToPage);
       applyDrawerFilters(state.query);
       renderDrawerResults();
     } catch (error) {
-      state.savingEditPageId = null;
+      setDrawerSavingEdit(state, null);
       renderDrawerResults();
       console.error('[newtab] Failed to update page:', error);
       reportFailure('Failed to update page. Please try again.');
@@ -488,9 +546,7 @@ export function createDrawerDataController({
 
     // Empty query: nothing to search semantically. Clear any prior results.
     if (!trimmedQuery) {
-      state.semanticResults = [];
-      state.semanticQuery = '';
-      state.semanticLoading = false;
+      setDrawerSemantic(state, { results: [], query: '', loading: false });
       renderDrawerResults();
       return;
     }
@@ -498,20 +554,13 @@ export function createDrawerDataController({
     // Only attempt semantic search when the API supports it; otherwise no-op
     // rather than erroring, so the saved-page filter still works.
     if (typeof api?.searchContent !== 'function') {
-      state.semanticResults = [];
-      state.semanticQuery = trimmedQuery;
-      state.semanticLoading = false;
+      setDrawerSemantic(state, { results: [], query: trimmedQuery, loading: false });
       renderDrawerResults();
       return;
     }
 
-    const requestId = state.semanticRequestId + 1;
-    state.semanticRequestId = requestId;
-    state.semanticQuery = trimmedQuery;
-    // Clear prior results so the loading state is shown on every new search,
-    // including follow-on tag clicks from an existing results page.
-    state.semanticResults = [];
-    state.semanticLoading = true;
+    const requestId = nextDrawerSemanticRequestId(state);
+    setDrawerSemantic(state, { query: trimmedQuery, results: [], loading: true });
     renderDrawerResults();
 
     // Run the search inside a Sentry span when available (production) so the
@@ -547,15 +596,15 @@ export function createDrawerDataController({
       }
 
       const results = Array.isArray(response?.results) ? response.results : [];
-      state.semanticResults = results.map(result => result?.thing_data).filter(Boolean);
+      setDrawerSemantic(state, { results: results.map(result => result?.thing_data).filter(Boolean) });
     } catch (error) {
       console.error('[newtab] Semantic search failed:', error);
       if (state.semanticRequestId === requestId) {
-        state.semanticResults = [];
+        setDrawerSemantic(state, { results: [] });
       }
     } finally {
       if (state.semanticRequestId === requestId) {
-        state.semanticLoading = false;
+        setDrawerSemantic(state, { loading: false });
         renderDrawerResults();
       }
     }
@@ -570,7 +619,7 @@ export function createDrawerDataController({
 
     // Any search intent (typed, submitted, cleared, topic-pill click) leaves
     // the sparse home view for the browse list.
-    state.view = 'browse';
+    setDrawerView(state, 'browse');
 
     if (!state.hasInitialized) {
       await loadDrawerBasePages({ query: trimmedQuery, syncUrl });
@@ -598,87 +647,27 @@ export function createDrawerDataController({
     }
     try {
       const domains = await api.getDomains();
-      state.domains = Array.isArray(domains) ? domains : [];
+      setDrawerDomains(state, Array.isArray(domains) ? domains : []);
       return state.domains;
     } catch (error) {
       console.error('Failed to load domains:', error);
-      state.domains = [];
+      setDrawerDomains(state, []);
       return state.domains;
     }
   }
 
   // Load pages scoped to a domain (broad category), using the same per-scope
-  // warm-cache approach as project pages.
-  async function loadDrawerDomainPages(domain, { query = state.query, syncUrl = true } = {}) {
+  // warm-cache approach as project pages. Thin wrapper over loadDrawerScope —
+  // see the scope-loading section above for the shared algorithm.
+  async function loadDrawerDomainPages(domain, options) {
     if (!domain) {
-      await loadDrawerBasePages({ query, syncUrl });
-      return;
+      return loadDrawerBasePages(options);
     }
-
-    // Selecting a domain scope leaves the sparse home view.
-    state.view = 'browse';
-    resetRenderLimit();
-    const requestId = ++state.requestId;
-    const trimmedQuery = query.trim();
-
-    state.isLoading = true;
-    setDrawerSearchValue(trimmedQuery);
-
-    if (syncUrl && isDrawerOpen()) {
-      updateDrawerUrl(true, trimmedQuery);
-    }
-
-    if (!(await canHydrateDrawerWithWarmCache(api, getCurrentUser))) {
-      state.isLoading = false;
-      state.hasInitialized = true;
-      savedPagesStore.reset({ emit: false });
-      getDomainSavedPagesStore(domain)?.reset({ emit: false });
-      state.allPages = [];
-      state.loadedProjectPages = [];
-      state.pages = [];
-      renderDrawerSignInState();
-      return;
-    }
-
-    const domainSavedPagesStore = getDomainSavedPagesStore(domain);
-    const domainSnapshot = domainSavedPagesStore?.getSnapshot?.() || null;
-    if (
-      domainSavedPagesStore &&
-      !domainSnapshot?.allPages?.length &&
-      !hasRenderableWarmCache(domainSnapshot)
-    ) {
-      renderDrawerLoadingState(trimmedQuery ? 'Searching pages from this domain…' : 'Gathering pages from this domain…');
-    }
-
-    try {
-      const snapshot = await domainSavedPagesStore.hydrate();
-
-      if (requestId !== state.requestId) {
-        return;
-      }
-
-      syncDomainDrawerStateFromStore(domain, snapshot, {
-        query: trimmedQuery,
-        render: false
-      });
-      state.hasInitialized = true;
-      renderDrawerResults();
-    } catch (error) {
-      if (requestId !== state.requestId) {
-        return;
-      }
-
-      console.error('[newtab] Domain drawer load failed:', error);
-      renderDrawerErrorState(error.message || 'Could not reach pages from this domain.');
-    } finally {
-      if (requestId === state.requestId) {
-        state.isLoading = false;
-      }
-    }
+    return loadDrawerScope(domainScope(domain), options);
   }
 
   function resetRenderLimit() {
-    state.renderLimit = INITIAL_RENDER_LIMIT;
+    resetDrawerRenderLimit(state);
   }
 
   // Track in-flight lazy loads so concurrent scroll events don't stack calls.
@@ -697,7 +686,7 @@ export function createDrawerDataController({
 
     const fullCount = state.pages.length;
     if (state.renderLimit < fullCount) {
-      state.renderLimit += RENDER_LIMIT_INCREMENT;
+      growDrawerRenderLimit(state);
       renderDrawerResults();
     }
 
@@ -736,6 +725,7 @@ export function createDrawerDataController({
     loadDrawerDomainPages,
     loadDrawerProjectPages,
     loadDrawerResults,
+    loadDrawerScopeForCurrentSelection,
     loadSemanticResults,
     resetRenderLimit
   };

--- a/src/newtab-drawer-runtime.js
+++ b/src/newtab-drawer-runtime.js
@@ -8,7 +8,7 @@ import {
 import { initSavedPagesDrawerEvents } from './newtab-drawer-events.js';
 import { createDrawerShellController } from './newtab-drawer-shell.js';
 import { createDrawerSyncCoordinator } from './newtab-drawer-sync.js';
-import { createInitialDrawerState } from './newtab-drawer-state.js';
+import { createInitialDrawerState, resetDrawerState, setDrawerInitialized } from './newtab-drawer-state.js';
 import { PINNED_PAGES_SCOPE_ID } from './project-manager-state.js';
 import { createDrawerUiController } from './newtab-drawer-ui.js';
 import { createSavedPagesView } from './newtab-drawer-view.js';
@@ -29,13 +29,10 @@ export function createSavedPagesDrawerController({
 }) {
   const {
     createDrawerDataControllerFn = createDrawerDataController,
-    createDrawerFiltersApplierFn = createDrawerFiltersApplier,
     createDrawerShellControllerFn = createDrawerShellController,
-    createDrawerStateSyncHelpersFn = createDrawerStateSyncHelpers,
     createDrawerSyncCoordinatorFn = createDrawerSyncCoordinator,
     createDrawerUiControllerFn = createDrawerUiController,
     createInitialDrawerStateFn = createInitialDrawerState,
-    createSavedPagesTotalNotifierFn = createSavedPagesTotalNotifier,
     createSavedPagesViewFn = createSavedPagesView,
     getDrawerCurrentUserFn = getDrawerCurrentUser,
     initSavedPagesDrawerEventsFn = initSavedPagesDrawerEvents
@@ -56,7 +53,7 @@ export function createSavedPagesDrawerController({
   let dataController;
   let savedPagesView;
   let uiController;
-  const notifySavedPagesTotalChange = createSavedPagesTotalNotifierFn({
+  const notifySavedPagesTotalChange = createSavedPagesTotalNotifier({
     savedPagesStore,
     onSavedPagesTotalChange
   });
@@ -70,7 +67,7 @@ export function createSavedPagesDrawerController({
   // init, refreshed on sign-in, and cleared on sign-out.
   let cachedUser = null;
   const getCurrentUser = () => cachedUser;
-  const applyDrawerFilters = createDrawerFiltersApplierFn({
+  const applyDrawerFilters = createDrawerFiltersApplier({
     state,
     projectManager,
     getSavedPagesView: () => savedPagesView
@@ -110,7 +107,7 @@ export function createSavedPagesDrawerController({
     projectSidebar?.classList?.remove('hidden');
     return uiController.renderResults(...args);
   };
-  const { syncDrawerStateFromStore, syncProjectsStateFromStore } = createDrawerStateSyncHelpersFn({
+  const { syncDrawerStateFromStore, syncProjectsStateFromStore } = createDrawerStateSyncHelpers({
     state,
     projectManager,
     getSavedPagesView: () => savedPagesView,
@@ -207,7 +204,7 @@ export function createSavedPagesDrawerController({
     renderDrawerSignInState,
     renderDrawerResults,
     resetDrawerState: () => {
-      Object.assign(state, createInitialDrawerStateFn());
+      resetDrawerState(state);
     },
     setSuppressSavedPagesStoreSync: (value) => {
       suppressSavedPagesStoreSync = value === true;
@@ -239,25 +236,23 @@ export function createSavedPagesDrawerController({
   // (which were never in the local in-memory store) actually appear.
   async function forceReload() {
     await refreshCachedUser();
-    state.hasInitialized = false;
+    setDrawerInitialized(state, false);
     savedPagesStore.reset({ emit: false });
-
+    // Reset the currently-selected scope's store so hydrate() does a full
+    // network fetch, not a warm-cache paint of the stale in-memory list. This
+    // mirrors the sign-in gate inside loadDrawerScope, but forceReload runs
+    // already-authenticated so it must reset up-front.
     if (state.selectedProjectId && state.selectedProjectId !== PINNED_PAGES_SCOPE_ID) {
-      // Reset the project store so hydrate() does a full network fetch, not a
-      // warm-cache paint of the stale in-memory list.
-      const projectId = state.selectedProjectId;
-      const projectStore = dataController.getProjectSavedPagesStore?.(projectId);
+      const projectStore = dataController.getProjectSavedPagesStore?.(state.selectedProjectId);
       projectStore?.reset({ emit: false });
-      await dataController.loadDrawerProjectPages(projectId, {
-        query: shellController.getSearchQuery(),
-        syncUrl: false
-      });
-    } else {
-      await dataController.loadDrawerBasePages({
-        query: shellController.getSearchQuery(),
-        syncUrl: false
-      });
     }
+    // loadDrawerScopeForCurrentSelection picks all/project/domain from the
+    // live selection — previously this branched on project-vs-base only and
+    // silently routed a domain selection to all-pages (a latent bug).
+    await dataController.loadDrawerScopeForCurrentSelection({
+      query: shellController.getSearchQuery(),
+      syncUrl: false
+    });
   }
 
   function handleSignedOut() {

--- a/src/newtab-drawer-state.js
+++ b/src/newtab-drawer-state.js
@@ -59,6 +59,207 @@ export function createInitialDrawerState() {
   };
 }
 
+// --- Single mutation owner -------------------------------------------------
+//
+// Every write to the drawer `state` bag MUST go through one of the functions
+// below. This module is the complete answer to "who sets a drawer state field?"
+// — keeping all writes here means a render path can be followed without holding
+// six files of mutation in your head, and the races that used to require
+// long narrating comments (warming UI, hasInitialized resets) now have one
+// search location.
+//
+// The bag stays a plain readable object: functions take `state` as their first
+// arg and mutate it in place. Normalization that the savedPagesView proxy used
+// to apply (array-coerce, `|| null`, the 'browse'|'home' clamp) lives here now,
+// so direct-writers and proxy-writers share one path.
+
+export function resetDrawerState(state) {
+  Object.assign(state, createInitialDrawerState());
+}
+
+// --- Load lifecycle --------------------------------------------------------
+
+export function setDrawerLoading(state, value) {
+  state.isLoading = value === true;
+}
+
+// Monotonic stale-guard token. Returns the new id so callers can capture it
+// before the await that may be superseded (the standard ++write/===read guard).
+export function nextDrawerRequestId(state) {
+  state.requestId += 1;
+  return state.requestId;
+}
+
+export function setDrawerInitialized(state, value) {
+  state.hasInitialized = value === true;
+}
+
+// --- Pages -----------------------------------------------------------------
+
+export function setDrawerAllPages(state, pages) {
+  state.allPages = Array.isArray(pages) ? pages : [];
+}
+
+export function setDrawerRenderedPages(state, pages) {
+  state.pages = Array.isArray(pages) ? pages : [];
+}
+
+// null clears the scope-source overlay (back to the All-pages view); an array
+// installs it for a project/domain scope. Stored on the same field for both.
+export function setDrawerLoadedScopePages(state, pages) {
+  state.loadedProjectPages = Array.isArray(pages) ? pages : null;
+}
+
+// Apply a single updater to the page collections the drawer renders from. Used
+// by optimistic edit/pin/delete flows that must update the in-memory copy in
+// lockstep. Returns the updated page for convenience.
+export function updateDrawerPageCollections(state, id, updater) {
+  if (typeof updater !== 'function') return null;
+  const apply = (page) => (page.id === id ? updater(page) : page);
+  state.allPages = state.allPages.map(apply);
+  if (Array.isArray(state.loadedProjectPages)) {
+    state.loadedProjectPages = state.loadedProjectPages.map(apply);
+  }
+  state.pages = state.pages.map(apply);
+  return state.allPages.find(page => page.id === id) || null;
+}
+
+// --- Projects --------------------------------------------------------------
+
+export function setDrawerProjects(state, projects) {
+  state.projects = Array.isArray(projects) ? projects : [];
+}
+
+export function setDrawerProjectsLoading(state, value) {
+  state.projectsLoading = value === true;
+}
+
+export function setDrawerProjectsAvailability(state, { available, message } = {}) {
+  if (available !== undefined) state.projectsAvailable = available !== false;
+  if (message !== undefined) state.projectsUnavailableMessage = message || '';
+}
+
+// --- Scope selection -------------------------------------------------------
+
+export function selectDrawerProject(state, projectId) {
+  state.selectedProjectId = projectId || null;
+}
+
+export function selectDrawerDomain(state, domainId) {
+  state.selectedDomainId = domainId || null;
+}
+
+export function setDrawerView(state, value) {
+  state.view = value === 'browse' ? 'browse' : 'home';
+}
+
+// --- Edit lifecycle --------------------------------------------------------
+
+export function setDrawerEditingPage(state, id) {
+  state.editingPageId = id || null;
+}
+
+export function setDrawerSavingEdit(state, id) {
+  state.savingEditPageId = id || null;
+}
+
+// --- Render window ---------------------------------------------------------
+
+export function resetDrawerRenderLimit(state) {
+  state.renderLimit = INITIAL_RENDER_LIMIT;
+}
+
+export function growDrawerRenderLimit(state, increment = RENDER_LIMIT_INCREMENT) {
+  state.renderLimit += increment;
+}
+
+// --- Semantic search -------------------------------------------------------
+
+export function nextDrawerSemanticRequestId(state) {
+  state.semanticRequestId += 1;
+  return state.semanticRequestId;
+}
+
+export function setDrawerSemantic(state, { results, query, loading } = {}) {
+  if (results !== undefined) state.semanticResults = Array.isArray(results) ? results : [];
+  if (query !== undefined) state.semanticQuery = query;
+  if (loading !== undefined) state.semanticLoading = loading === true;
+}
+
+// --- Domains ---------------------------------------------------------------
+
+export function setDrawerDomains(state, domains) {
+  state.domains = Array.isArray(domains) ? domains : [];
+}
+
+// --- Warming ---------------------------------------------------------------
+// The most heavily cross-closure cluster: armed by loadDrawerBasePages, driven
+// by the store subscriber, cleared on completion or sign-out. Concentrating
+// these writes here is the direct fix for the trampling race the long comments
+// used to narrate.
+
+export function beginDrawerWarming(state, progress) {
+  state.warmUpInProgress = true;
+  if (progress !== undefined) {
+    state.warmUpProgress = progress;
+  } else {
+    state.warmUpProgress = { percent: 0, indeterminate: true };
+  }
+}
+
+export function updateDrawerWarming(state, progress) {
+  state.warmUpInProgress = true;
+  if (progress !== undefined) {
+    state.warmUpProgress = progress;
+  }
+}
+
+export function clearDrawerWarming(state) {
+  // Clear the flag and the clamp bookkeeping, but leave warmUpProgress at its
+  // last value. Both call sites (the completion timer and the drawer-closed
+  // drop) want the bar to hold its final reading — the completion path shows
+  // 100% briefly before the dispatcher switches to cards, and a full reset
+  // (including progress) only happens on sign-out via resetDrawerState.
+  state.warmUpInProgress = false;
+  state.warmUpLastPercent = 0;
+  state.warmUpDeterminate = false;
+}
+
+// --- Totals ----------------------------------------------------------------
+// Normally derived inside applyDrawerFilters/syncDrawerStateFromStore, but the
+// savedPagesView proxy exposes totalPages/allItemsTotal setters (used by some
+// project-manager paths) so they need a home here too to keep the invariant.
+
+export function setDrawerTotal(state, value) {
+  state.total = value;
+}
+
+export function setDrawerAllItemsTotal(state, value) {
+  state.allItemsTotal = value;
+}
+
+// --- Editor + filter -------------------------------------------------------
+// These had no proxy setter previously, so nested writes
+// (state.currentFilter.projectId = x) bypassed normalization. Exposing them as
+// first-class mutations keeps the "one write surface" invariant honest.
+
+function getDefaultProjectEditorState() {
+  return { pageId: null, query: '' };
+}
+
+export function setDrawerProjectEditorState(state, value) {
+  state.projectEditorState = value || getDefaultProjectEditorState();
+}
+
+export function setDrawerCurrentFilter(state, { search, projectId, cursor } = {}) {
+  if (!state.currentFilter || typeof state.currentFilter !== 'object') {
+    state.currentFilter = { search: '', projectId: null, cursor: null };
+  }
+  if (search !== undefined) state.currentFilter.search = search;
+  if (projectId !== undefined) state.currentFilter.projectId = projectId || null;
+  if (cursor !== undefined) state.currentFilter.cursor = cursor || null;
+}
+
 // Computes the warming progress bar value from the store snapshot, persisting
 // the clamp state on `state` so the bar never decreases across renders. Once a
 // determinate reading has been shown, it never goes back below it; an unknown
@@ -92,6 +293,12 @@ export function computeWarmingProgress(snapshot, state, { complete = false } = {
   state.warmUpLastPercent = percent;
   return { percent, indeterminate: false };
 }
+
+// Note: computeWarmingProgress persists its clamp side-effects directly on the
+// warming fields. Those reads/writes are intrinsic to the clamp math (the
+// computed value depends on the prior value), so they stay inline rather than
+// threading through updateDrawerWarming — which would require the prior value
+// before computing the next, defeating the single-assignment intent.
 
 // Returns true when the store snapshot reflects a terminal idle state — i.e.
 // the store has finished whatever work the warm-up was waiting on.
@@ -139,7 +346,7 @@ export function applyDrawerFilters({
 }) {
   const trimmedQuery = query.trim();
   state.query = trimmedQuery;
-  state.currentFilter.search = trimmedQuery;
+  setDrawerCurrentFilter(state, { search: trimmedQuery });
 
   // When a project or domain scope is active, use the scoped page set
   // (loadedProjectPages holds domain pages too). Otherwise use all pages.
@@ -153,12 +360,12 @@ export function applyDrawerFilters({
   state.total = scopedPages.length;
 
   if (!trimmedQuery) {
-    state.pages = [...scopedPages];
+    setDrawerRenderedPages(state, [...scopedPages]);
     return;
   }
 
   const loweredQuery = trimmedQuery.toLowerCase();
-  state.pages = scopedPages.filter(page => getDrawerSearchableText(page).includes(loweredQuery));
+  setDrawerRenderedPages(state, scopedPages.filter(page => getDrawerSearchableText(page).includes(loweredQuery)));
 }
 
 export function syncDrawerStateFromStore({
@@ -171,8 +378,8 @@ export function syncDrawerStateFromStore({
   query = state.query,
   render = state.hasInitialized
 }) {
-  state.allPages = snapshot.allPages || [];
-  state.loadedProjectPages = null;
+  setDrawerAllPages(state, snapshot.allPages || []);
+  setDrawerLoadedScopePages(state, null);
   state.allItemsTotal = Math.max(
     typeof snapshot.total === 'number' ? snapshot.total : 0,
     state.allPages.length
@@ -194,9 +401,8 @@ export function syncProjectsStateFromStore({
   renderDrawerChrome,
   render = state.hasInitialized
 }) {
-  state.projects = snapshot.projects || snapshot.allPages || [];
-  state.projectsAvailable = true;
-  state.projectsUnavailableMessage = '';
+  setDrawerProjects(state, snapshot.projects || snapshot.allPages || []);
+  setDrawerProjectsAvailability(state, { available: true, message: '' });
   projectManager.refreshProjectCounts(savedPagesView);
 
   if (render) {

--- a/src/newtab-drawer-sync-lifecycle.js
+++ b/src/newtab-drawer-sync-lifecycle.js
@@ -1,4 +1,5 @@
 import { canHydrateDrawerWithWarmCache } from './newtab-drawer-coordination.js';
+import { setDrawerInitialized } from './newtab-drawer-state.js';
 
 export function createDrawerSyncLifecycle({
   api,
@@ -63,13 +64,13 @@ export function createDrawerSyncLifecycle({
         return;
       }
 
-      state.hasInitialized = false;
+      setDrawerInitialized(state, false);
       savedPagesStore.reset({ emit: false });
       await loadDrawerResults(getSearchQuery(), { syncUrl: false });
       return;
     }
 
-    state.hasInitialized = false;
+    setDrawerInitialized(state, false);
     savedPagesStore.reset({ emit: false });
     await loadSummary();
   }

--- a/src/newtab-drawer-sync-observers.js
+++ b/src/newtab-drawer-sync-observers.js
@@ -1,6 +1,12 @@
 import { isSavedPagesCacheInvalidation } from './saved-pages-cache.js';
 import { PINNED_PAGES_SCOPE_ID } from './project-manager-state.js';
-import { computeWarmingProgress, isWarmUpComplete } from './newtab-drawer-state.js';
+import {
+  clearDrawerWarming,
+  computeWarmingProgress,
+  isWarmUpComplete,
+  setDrawerInitialized,
+  updateDrawerWarming
+} from './newtab-drawer-state.js';
 import {
   PENDING_SAVES_KEY,
   getPendingSaves,
@@ -46,7 +52,7 @@ export function createDrawerCacheInvalidationObserver({
   function syncSavedPagesAfterCacheInvalidation() {
     windowObj.clearTimeout(savedPagesCacheRefreshTimer);
     savedPagesCacheRefreshTimer = windowObj.setTimeout(() => {
-      state.hasInitialized = false;
+      setDrawerInitialized(state, false);
 
       if (!getCurrentUser()) {
         return;
@@ -239,8 +245,7 @@ export function createDrawerStoreSubscriptions({
         clearCompletionTimer();
 
         const progress = computeWarmingProgress(snapshot, state, { complete });
-        state.warmUpInProgress = true;
-        state.warmUpProgress = progress;
+        updateDrawerWarming(state, progress);
 
         // Route through the dispatcher — the single render authority. It sees
         // warmUpInProgress and renders the warming pane, never cards.
@@ -251,9 +256,7 @@ export function createDrawerStoreSubscriptions({
           // then clear the flag so the next dispatcher call renders cards.
           completionTimer = timers.setTimeout(() => {
             completionTimer = null;
-            state.warmUpInProgress = false;
-            state.warmUpLastPercent = 0;
-            state.warmUpDeterminate = false;
+            clearDrawerWarming(state);
             // The store snapshot already populated state.allPages via the
             // loadDrawerBasePages -> syncDrawerStateFromStore path; the
             // dispatcher reads it now that the warming flag is clear.
@@ -278,9 +281,7 @@ export function createDrawerStoreSubscriptions({
       // state so a future warm-up starts fresh.
       if (state.warmUpInProgress && !isDrawerOpen()) {
         clearCompletionTimer();
-        state.warmUpInProgress = false;
-        state.warmUpLastPercent = 0;
-        state.warmUpDeterminate = false;
+        clearDrawerWarming(state);
       }
 
       if (

--- a/src/newtab-drawer-view.js
+++ b/src/newtab-drawer-view.js
@@ -1,8 +1,19 @@
 import { PINNED_PAGES_SCOPE_ID } from './project-manager-state.js';
-
-function getDefaultProjectEditorState() {
-  return { pageId: null, query: '' };
-}
+import {
+  selectDrawerDomain,
+  selectDrawerProject,
+  setDrawerAllItemsTotal,
+  setDrawerAllPages,
+  setDrawerCurrentFilter,
+  setDrawerDomains,
+  setDrawerProjectEditorState,
+  setDrawerProjects,
+  setDrawerProjectsAvailability,
+  setDrawerProjectsLoading,
+  setDrawerRenderedPages,
+  setDrawerTotal,
+  setDrawerView
+} from './newtab-drawer-state.js';
 
 function hasSelectedProjectScope(state) {
   return Boolean(state.selectedProjectId && state.selectedProjectId !== PINNED_PAGES_SCOPE_ID);
@@ -27,83 +38,94 @@ export function createSavedPagesView({
       return state.allPages;
     },
     set allPages(value) {
-      state.allPages = Array.isArray(value) ? value : [];
+      setDrawerAllPages(state, value);
     },
     get pages() {
       return state.pages;
     },
     set pages(value) {
-      state.pages = Array.isArray(value) ? value : [];
+      setDrawerRenderedPages(state, value);
     },
     get projects() {
       return state.projects;
     },
     set projects(value) {
-      state.projects = Array.isArray(value) ? value : [];
+      setDrawerProjects(state, value);
     },
     get domains() {
       return state.domains;
     },
     set domains(value) {
-      state.domains = Array.isArray(value) ? value : [];
+      setDrawerDomains(state, value);
     },
     get selectedDomainId() {
       return state.selectedDomainId;
     },
     set selectedDomainId(value) {
-      state.selectedDomainId = value || null;
+      selectDrawerDomain(state, value);
     },
     get projectsLoading() {
       return state.projectsLoading;
     },
     set projectsLoading(value) {
-      state.projectsLoading = value === true;
+      setDrawerProjectsLoading(state, value);
     },
     get selectedProjectId() {
       return state.selectedProjectId;
     },
     set selectedProjectId(value) {
-      state.selectedProjectId = value || null;
+      selectDrawerProject(state, value);
     },
     get view() {
       return state.view;
     },
     set view(value) {
-      state.view = value === 'browse' ? 'browse' : 'home';
+      setDrawerView(state, value);
     },
     get projectsAvailable() {
       return state.projectsAvailable;
     },
     set projectsAvailable(value) {
-      state.projectsAvailable = value !== false;
+      setDrawerProjectsAvailability(state, { available: value });
     },
     get projectsUnavailableMessage() {
       return state.projectsUnavailableMessage;
     },
     set projectsUnavailableMessage(value) {
-      state.projectsUnavailableMessage = value || '';
+      setDrawerProjectsAvailability(state, { message: value });
     },
     projectsStore,
     get projectEditorState() {
       return state.projectEditorState;
     },
     set projectEditorState(value) {
-      state.projectEditorState = value || getDefaultProjectEditorState();
+      setDrawerProjectEditorState(state, value);
     },
     get currentFilter() {
       return state.currentFilter;
+    },
+    set currentFilter(value) {
+      // Whole-object replacement: rebuild with normalization. Nested field
+      // writes (dashboard.currentFilter.projectId = x) go through the getter's
+      // live object and are NOT routed here — project-manager code calls
+      // setDrawerCurrentFilter directly for those, see pm-actions.js.
+      setDrawerCurrentFilter(state, {
+        search: value?.search,
+        projectId: value?.projectId,
+        cursor: value?.cursor
+      });
     },
     get totalPages() {
       return state.total;
     },
     set totalPages(value) {
-      state.total = value;
+      setDrawerTotal(state, value);
     },
     get allItemsTotal() {
       return state.allItemsTotal;
     },
     set allItemsTotal(value) {
-      state.allItemsTotal = value;
+      setDrawerAllItemsTotal(state, value);
     },
     getCurrentUser,
     async persistAllPages() {

--- a/src/newtab-drawer.js
+++ b/src/newtab-drawer.js
@@ -1,4 +1,4 @@
-export { createSavedPagesDrawerController } from './newtab-drawer-controller.js';
+export { createSavedPagesDrawerController } from './newtab-drawer-runtime.js';
 export {
   createProjectSavedPagesStore,
   createProjectsStore,

--- a/src/send-runtime-message.js
+++ b/src/send-runtime-message.js
@@ -1,0 +1,46 @@
+// send-runtime-message.js — single runtime.sendMessage wrapper for every surface.
+//
+// Works in all three load contexts the extension has:
+//   - toolbar popup (no polyfill → chrome.runtime is callback-based),
+//   - newtab (polyfill injected async → may be callback OR promise depending
+//     on load timing),
+//   - anywhere the polyfill has settled, or Firefox native (promise-based).
+//
+// The strategy is the only one that survives all three: always pass a callback
+// (Chrome shape), and ALSO consume the return value if it's a promise
+// (Firefox/polyfill shape). Exactly one of those paths fires depending on the
+// runtime; registering a callback that will be ignored is harmless.
+//
+// The caller owns the error policy: this helper rejects on lastError/throw,
+// and the caller decides whether to surface or swallow (e.g. the realtime
+// relay intentionally swallows to console.warn).
+
+export function sendRuntimeMessage(runtime, message) {
+  if (!runtime?.sendMessage) {
+    return Promise.reject(new Error('Browser runtime API not available'));
+  }
+
+  return new Promise((resolve, reject) => {
+    try {
+      // Chrome (callback) shape: pass a callback that resolves/rejects.
+      const response = runtime.sendMessage(message, (res) => {
+        const lastError = runtime.lastError;
+        if (lastError) {
+          reject(new Error(lastError.message));
+          return;
+        }
+        resolve(res);
+      });
+
+      // Firefox / polyfill (promise) shape: if sendMessage returned a thenable,
+      // it ignores the callback and resolves via this promise instead. Wire it
+      // up so we resolve once either way. (On Chrome, response is undefined and
+      // this branch is skipped.)
+      if (response && typeof response.then === 'function') {
+        response.then(resolve, reject);
+      }
+    } catch (error) {
+      reject(error);
+    }
+  });
+}

--- a/src/shared-ui-helpers.js
+++ b/src/shared-ui-helpers.js
@@ -1,0 +1,44 @@
+// shared-ui-helpers.js — tiny DOM helpers shared across the modal surfaces
+// (sharing-centre, import-panel, data-sync-centre). Each surface used to carry
+// its own copy of these; the copies had drifted in which options they supported
+// (e.g. the `html` option) and all three independently fixed the same
+// setAttribute(key, null) bug. Centralizing keeps them from drifting again.
+//
+// Both helpers close over a documentObj so the surfaces can inject a test
+// document (they already accept one via their factory param).
+
+// Build a DOM element from a tag + options. Supports className, text, html,
+// attrs (null/undefined values skipped — see below), onClick, and children.
+//
+// The attrs null-guard exists because setAttribute stringifies null to "null",
+// which for boolean attributes like 'disabled' would wrongly enable them.
+// Callers can conditionally omit an attribute with `disabled: busy ? 'disabled' : null`.
+export function createEl(documentObj = document) {
+  return function el(tag, { className, text, html, attrs, onClick, children } = {}) {
+    const node = documentObj.createElement(tag);
+    if (className) node.className = className;
+    if (text != null) node.textContent = text;
+    if (html != null) node.innerHTML = html;
+    if (attrs) {
+      for (const [key, value] of Object.entries(attrs)) {
+        if (value != null) node.setAttribute(key, value);
+      }
+    }
+    if (onClick) node.onclick = onClick;
+    if (children) node.append(...children);
+    return node;
+  };
+}
+
+// getElementById wrapped in a null-safe try/catch. Returns null when the
+// document or element is absent (standalone preview, missing markup) rather
+// than throwing — so a surface can probe for optional elements defensively.
+export function createQueryId(documentObj = document) {
+  return function queryId(id) {
+    try {
+      return documentObj?.getElementById?.(id) ?? null;
+    } catch {
+      return null;
+    }
+  };
+}

--- a/src/sharing-centre.js
+++ b/src/sharing-centre.js
@@ -14,6 +14,7 @@
 
 import { isOwnedProject } from './project-manager-state.js';
 import { createDialogLifecycle } from './dialog-lifecycle.js';
+import { createEl, createQueryId } from './shared-ui-helpers.js';
 
 export function createSharingCentre({
   api,
@@ -22,13 +23,7 @@ export function createSharingCentre({
   getProjectManager,
   onProjectsChanged = () => {}
 } = {}) {
-  const queryId = (id) => {
-    try {
-      return documentObj?.getElementById?.(id) ?? null;
-    } catch {
-      return null;
-    }
-  };
+  const queryId = createQueryId(documentObj);
   const getBackdrop = () => queryId('sharing-centre-backdrop');
   const getDialog = () => queryId('sharing-centre-dialog');
 
@@ -43,21 +38,7 @@ export function createSharingCentre({
     }
   });
 
-  function el(tag, { className, text, attrs, onClick, children } = {}) {
-    const node = documentObj.createElement(tag);
-    if (className) node.className = className;
-    if (text != null) node.textContent = text;
-    if (attrs) {
-      // Skip null/undefined values: setAttribute stringifies null to "null",
-      // which for boolean attributes like 'disabled' would wrongly enable them.
-      for (const [key, value] of Object.entries(attrs)) {
-        if (value != null) node.setAttribute(key, value);
-      }
-    }
-    if (onClick) node.onclick = onClick;
-    if (children) node.append(...children);
-    return node;
-  }
+  const el = createEl(documentObj);
 
   function audienceLabel(project) {
     if (project.visibility !== 'company' || !project.company_domain) {

--- a/src/toolbar-popup.js
+++ b/src/toolbar-popup.js
@@ -1,3 +1,5 @@
+import { sendRuntimeMessage } from './send-runtime-message.js';
+
 const browserApi = globalThis.browser?.runtime ? globalThis.browser : globalThis.chrome;
 
 const saveDefaultBtn = document.getElementById('save-default-btn');
@@ -20,26 +22,8 @@ function setBusy(isBusy, message = '') {
   setStatus(message, isBusy ? 'info' : statusEl?.dataset?.state || 'info');
 }
 
-async function sendRuntimeMessage(message) {
-  if (!browserApi?.runtime?.sendMessage) {
-    throw new Error('Browser runtime API not available');
-  }
-
-  if (globalThis.browser?.runtime?.sendMessage) {
-    return await globalThis.browser.runtime.sendMessage(message);
-  }
-
-  return await new Promise((resolve, reject) => {
-    globalThis.chrome.runtime.sendMessage(message, (response) => {
-      const runtimeError = globalThis.chrome.runtime?.lastError;
-      if (runtimeError) {
-        reject(new Error(runtimeError.message));
-        return;
-      }
-
-      resolve(response);
-    });
-  });
+function send(message) {
+  return sendRuntimeMessage(browserApi.runtime, message);
 }
 
 function renderProjects(projects) {
@@ -74,7 +58,7 @@ async function loadProjects() {
   projectList?.setAttribute('aria-busy', 'true');
   setStatus('');
 
-  const response = await sendRuntimeMessage({ action: 'getToolbarProjects' });
+  const response = await send({ action: 'getToolbarProjects' });
   if (!response?.success) {
     renderProjects([]);
     setStatus(response?.error || 'Failed to load projects.', 'error');
@@ -88,7 +72,7 @@ async function loadProjects() {
 async function handleSave(projectId = null, loadingMessage = 'Saving...') {
   setBusy(true, loadingMessage);
 
-  const response = await sendRuntimeMessage({
+  const response = await send({
     action: 'saveCurrentPage',
     ...(projectId ? { projectId } : {})
   });

--- a/src/warm-cache-list-store.js
+++ b/src/warm-cache-list-store.js
@@ -236,10 +236,6 @@ export class WarmCacheListStore {
       return this.getSnapshot();
     }
 
-    if (this.state.requestId !== requestId) {
-      return this.getSnapshot();
-    }
-
     this.state.warmCacheState = createWarmCacheState(warmCache.status, {
       ageMs: warmCache.ageMs,
       timestamp: warmCache.timestamp,

--- a/tests/unit/auth-menu.test.js
+++ b/tests/unit/auth-menu.test.js
@@ -1,6 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import '../../src/auth-menu.js';
+import { sendRuntimeMessage } from '../../src/send-runtime-message.js';
+
+// auth-menu.js is a classic script that reads window.sendRuntimeMessage
+// (seeded by config-loader.js in production). Seed it here so the real helper
+// is exercised — the tests previously mocked sendMessage as promise-returning,
+// which hid the callback-form path the helper exists to handle.
+beforeEach(() => {
+  window.sendRuntimeMessage = sendRuntimeMessage;
+});
 
 describe('AuthMenu.signIn', () => {
   beforeEach(() => {

--- a/tests/unit/newtab-drawer-runtime.test.js
+++ b/tests/unit/newtab-drawer-runtime.test.js
@@ -65,16 +65,10 @@ describe('newtab drawer runtime', () => {
       documentObj: { id: 'document' },
       dependencies: {
         createDrawerDataControllerFn: vi.fn(() => dataController),
-        createDrawerFiltersApplierFn: vi.fn(() => vi.fn()),
         createDrawerShellControllerFn: vi.fn(() => shellController),
-        createDrawerStateSyncHelpersFn: vi.fn(() => ({
-          syncDrawerStateFromStore: vi.fn(),
-          syncProjectsStateFromStore: vi.fn()
-        })),
         createDrawerSyncCoordinatorFn: vi.fn(() => syncCoordinator),
         createDrawerUiControllerFn: vi.fn(() => uiController),
         createInitialDrawerStateFn: vi.fn(() => state),
-        createSavedPagesTotalNotifierFn: vi.fn(() => vi.fn()),
         createSavedPagesViewFn: vi.fn(() => savedPagesView),
         getDrawerCurrentUserFn: vi.fn(() => ({ uid: 'user-1' })),
         initSavedPagesDrawerEventsFn
@@ -200,13 +194,8 @@ describe('newtab drawer runtime', () => {
           setDrawerToggleState: vi.fn(),
           updateDrawerUrl: vi.fn()
         })),
-        createDrawerStateSyncHelpersFn: vi.fn(() => ({
-          syncDrawerStateFromStore: vi.fn(),
-          syncProjectsStateFromStore: vi.fn()
-        })),
         createDrawerUiControllerFn: vi.fn(() => uiController),
         createInitialDrawerStateFn: vi.fn(() => state),
-        createSavedPagesTotalNotifierFn: vi.fn(() => vi.fn()),
         createSavedPagesViewFn: vi.fn(() => ({})),
         // Signed in for the restore path so shouldSyncDrawerStoreUpdate passes.
         getDrawerCurrentUserFn: vi.fn(() => ({ uid: 'user-1' })),
@@ -281,16 +270,12 @@ describe('newtab drawer runtime', () => {
           openSavedPagesDrawer: vi.fn(), setDrawerSearchValue: vi.fn(),
           setDrawerToggleState: vi.fn(), updateDrawerUrl: vi.fn()
         })),
-        createDrawerStateSyncHelpersFn: vi.fn(() => ({
-          syncDrawerStateFromStore: vi.fn(), syncProjectsStateFromStore: vi.fn()
-        })),
         createDrawerUiControllerFn: vi.fn(() => ({
           renderDrawerChrome: vi.fn(), renderErrorState: vi.fn(),
           renderLoadingState: vi.fn(), renderProjectSidebar: vi.fn(),
           refreshDrawerCard: vi.fn(), renderResults: vi.fn(), renderSignInState: vi.fn()
         })),
         createInitialDrawerStateFn: vi.fn(() => ({ hasInitialized: false })),
-        createSavedPagesTotalNotifierFn: vi.fn(() => vi.fn()),
         createSavedPagesViewFn: vi.fn(({ getCurrentUser }) => {
           viewGetCurrentUser = getCurrentUser;
           return { getCurrentUser };

--- a/tests/unit/newtab-drawer-state-ownership.test.js
+++ b/tests/unit/newtab-drawer-state-ownership.test.js
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import {
+  beginDrawerWarming,
+  clearDrawerWarming,
+  computeWarmingProgress,
+  createInitialDrawerState,
+  nextDrawerRequestId,
+  nextDrawerSemanticRequestId,
+  resetDrawerState,
+  selectDrawerDomain,
+  selectDrawerProject,
+  setDrawerAllPages,
+  setDrawerCurrentFilter,
+  setDrawerInitialized,
+  setDrawerLoadedScopePages,
+  setDrawerProjectsAvailability,
+  setDrawerSemantic,
+  setDrawerView,
+  updateDrawerPageCollections,
+  updateDrawerWarming
+} from '../../src/newtab-drawer-state.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const srcDir = resolve(repoRoot, 'src');
+
+// Files that own drawer state and are therefore the ONLY ones allowed to write
+// it directly. newtab-drawer-state.js is the single mutation owner; the view
+// proxy (newtab-drawer-view.js) delegates its setters through that module, so
+// its few remaining `state.total = value`-shaped lines must also route through
+// the setters — but since it's the proxy layer, we treat it as part of the
+// owned surface and exclude it from the scan.
+const OWNERS = new Set([
+  'newtab-drawer-state.js'
+]);
+
+// Reads that look like writes but aren't: comparisons (===), destructuring,
+// property access in template literals, etc. The scan below excludes any line
+// whose only `=` is part of `===` / `==` / `=>` / `!=`.
+const WRITE_RE = /\bstate\.[a-zA-Z_]+(?:\.[a-zA-Z_]+)?\s*(?:\+\+|--|(?:\+|-|\*|\/)?=(?!=))/;
+
+function directWriteLines(source) {
+  return source
+    .split('\n')
+    .map((line, i) => ({ line, no: i + 1 }))
+    .filter(({ line }) => {
+      if (line.trim().startsWith('//')) return false;
+      return WRITE_RE.test(line);
+    });
+}
+
+describe('drawer state has a single mutation owner', () => {
+  it('no newtab-drawer-*.js file outside newtab-drawer-state.js writes state directly', () => {
+    const drawerFiles = readdirSync(srcDir).filter((f) => /^newtab-drawer-.*\.js$/.test(f));
+    expect(drawerFiles.length).toBeGreaterThan(8); // sanity: the family exists
+
+    const violations = [];
+    for (const file of drawerFiles) {
+      if (OWNERS.has(file)) continue;
+      const source = readFileSync(resolve(srcDir, file), 'utf8');
+      const hits = directWriteLines(source);
+      for (const { no, line } of hits) {
+        violations.push(`${file}:${no}: ${line.trim()}`);
+      }
+    }
+
+    if (violations.length > 0) {
+      throw new Error(
+        'Direct drawer-state writes found outside the single mutation owner.\n' +
+          'Every write must route through a function in src/newtab-drawer-state.js ' +
+          '(this invariant is what makes the drawer render path followable without ' +
+          'holding six files of mutation in your head, and what prevents the races ' +
+          'that the warming-UI / hasInitialized comments used to narrate).\n' +
+          `Violations:\n  ${violations.join('\n  ')}`
+      );
+    }
+  });
+});
+
+describe('drawer state mutation functions', () => {
+  // The contract every mutation function must hold: it mutates the bag in
+  // place (so existing references observe the change) and applies the same
+  // normalization the old proxy setters did. These tests pin the behavior the
+  // callers and view proxy both depend on.
+
+  it('nextDrawerRequestId is monotonic and returns the new id', () => {
+    const state = createInitialDrawerState();
+    const a = nextDrawerRequestId(state);
+    const b = nextDrawerRequestId(state);
+    expect(a).toBe(1);
+    expect(b).toBe(2);
+    expect(b).toBe(state.requestId);
+  });
+
+  it('nextDrawerSemanticRequestId is monotonic and returns the new id', () => {
+    const state = createInitialDrawerState();
+    expect(nextDrawerSemanticRequestId(state)).toBe(1);
+    expect(nextDrawerSemanticRequestId(state)).toBe(2);
+  });
+
+  it('setDrawerAllPages coerces non-arrays to []', () => {
+    const state = createInitialDrawerState();
+    setDrawerAllPages(state, [{ id: 'p1' }]);
+    expect(state.allPages).toEqual([{ id: 'p1' }]);
+    setDrawerAllPages(state, null);
+    expect(state.allPages).toEqual([]);
+  });
+
+  it('setDrawerLoadedScopePages treats non-array as a clear (null)', () => {
+    const state = createInitialDrawerState();
+    setDrawerLoadedScopePages(state, [{ id: 'p1' }]);
+    expect(state.loadedProjectPages).toEqual([{ id: 'p1' }]);
+    setDrawerLoadedScopePages(state, 'nope');
+    expect(state.loadedProjectPages).toBeNull();
+  });
+
+  it('setDrawerView clamps to browse|home', () => {
+    const state = createInitialDrawerState();
+    setDrawerView(state, 'browse');
+    expect(state.view).toBe('browse');
+    setDrawerView(state, 'something-else');
+    expect(state.view).toBe('home');
+  });
+
+  it('selectDrawerProject / selectDrawerDomain coerce falsy to null', () => {
+    const state = createInitialDrawerState();
+    selectDrawerProject(state, 'p1');
+    expect(state.selectedProjectId).toBe('p1');
+    selectDrawerProject(state, '');
+    expect(state.selectedProjectId).toBeNull();
+    selectDrawerDomain(state, 'example.com');
+    expect(state.selectedDomainId).toBe('example.com');
+    selectDrawerDomain(state, undefined);
+    expect(state.selectedDomainId).toBeNull();
+  });
+
+  it('setDrawerProjectsAvailability coerces message to empty string', () => {
+    const state = createInitialDrawerState();
+    setDrawerProjectsAvailability(state, { available: false, message: 'unsupported' });
+    expect(state.projectsAvailable).toBe(false);
+    expect(state.projectsUnavailableMessage).toBe('unsupported');
+    setDrawerProjectsAvailability(state, { available: true, message: null });
+    expect(state.projectsAvailable).toBe(true);
+    expect(state.projectsUnavailableMessage).toBe('');
+  });
+
+  it('beginDrawerWarming / updateDrawerWarming / clearDrawerWarming manage the warming cluster', () => {
+    const state = createInitialDrawerState();
+    expect(state.warmUpInProgress).toBe(false);
+
+    beginDrawerWarming(state, { percent: 10, indeterminate: false });
+    expect(state.warmUpInProgress).toBe(true);
+    expect(state.warmUpProgress).toEqual({ percent: 10, indeterminate: false });
+
+    updateDrawerWarming(state, { percent: 50, indeterminate: false });
+    expect(state.warmUpInProgress).toBe(true);
+    expect(state.warmUpProgress.percent).toBe(50);
+
+    // clearDrawerWarming drops the flag + clamp bookkeeping but, by design,
+    // leaves warmUpProgress at its last reading — the completion UI holds 100%
+    // briefly before the dispatcher switches to cards.
+    clearDrawerWarming(state);
+    expect(state.warmUpInProgress).toBe(false);
+    expect(state.warmUpDeterminate).toBe(false);
+    expect(state.warmUpLastPercent).toBe(0);
+    expect(state.warmUpProgress.percent).toBe(50);
+  });
+
+  it('setDrawerSemantic applies partial updates and coerces results to an array', () => {
+    const state = createInitialDrawerState();
+    setDrawerSemantic(state, { query: 'cats', loading: true });
+    expect(state.semanticQuery).toBe('cats');
+    expect(state.semanticLoading).toBe(true);
+    setDrawerSemantic(state, { results: [{ id: 'r1' }] });
+    expect(state.semanticResults).toEqual([{ id: 'r1' }]);
+    expect(state.semanticLoading).toBe(true); // untouched by the results-only update
+    setDrawerSemantic(state, { results: null });
+    expect(state.semanticResults).toEqual([]);
+  });
+
+  it('updateDrawerPageCollections updates all three render sources and returns the updated page', () => {
+    const state = createInitialDrawerState();
+    state.allPages = [{ id: 'p1', pinned: false }, { id: 'p2', pinned: false }];
+    state.loadedProjectPages = [{ id: 'p1', pinned: false }];
+    state.pages = [{ id: 'p1', pinned: false }];
+    const updated = updateDrawerPageCollections(state, 'p1', (p) => ({ ...p, pinned: true }));
+    expect(updated).toEqual({ id: 'p1', pinned: true });
+    expect(state.allPages[0].pinned).toBe(true);
+    expect(state.allPages[1].pinned).toBe(false); // sibling untouched
+    expect(state.loadedProjectPages[0].pinned).toBe(true);
+    expect(state.pages[0].pinned).toBe(true);
+  });
+
+  it('resetDrawerState restores every field to initial values, in place', () => {
+    const state = createInitialDrawerState();
+    nextDrawerRequestId(state);
+    setDrawerAllPages(state, [{ id: 'p1' }]);
+    setDrawerInitialized(state, true);
+    beginDrawerWarming(state);
+    const originalRef = state;
+
+    resetDrawerState(state);
+
+    expect(state).toBe(originalRef); // in place — references still valid
+    expect(state.requestId).toBe(0);
+    expect(state.allPages).toEqual([]);
+    expect(state.hasInitialized).toBe(false);
+    expect(state.warmUpInProgress).toBe(false);
+  });
+
+  it('setDrawerCurrentFilter initializes a missing currentFilter and applies partial updates', () => {
+    const state = createInitialDrawerState();
+    delete state.currentFilter;
+    setDrawerCurrentFilter(state, { search: 'alpha' });
+    expect(state.currentFilter).toEqual({ search: 'alpha', projectId: null, cursor: null });
+    setDrawerCurrentFilter(state, { projectId: 'p1' });
+    expect(state.currentFilter.projectId).toBe('p1');
+    expect(state.currentFilter.search).toBe('alpha'); // untouched
+  });
+
+  it('computeWarmingProgress is monotonic once determinate', () => {
+    const state = createInitialDrawerState();
+    // 24/80 = 30%
+    const p1 = computeWarmingProgress({ total: 80, allPages: Array.from({ length: 24 }) }, state, {});
+    expect(p1.percent).toBe(30);
+    // A regression in the numerator (e.g. dedupe) must not lower the bar.
+    const p2 = computeWarmingProgress({ total: 80, allPages: Array.from({ length: 10 }) }, state, {});
+    expect(p2.percent).toBe(30);
+  });
+});

--- a/tests/unit/newtab.test.js
+++ b/tests/unit/newtab.test.js
@@ -944,6 +944,18 @@ describe('newtab modules', () => {
        ...(overrides.projectSavedPagesStore || {})
      };
      const createProjectSavedPagesStoreFn = overrides.createProjectSavedPagesStoreFn || vi.fn(() => projectSavedPagesStore);
+     let domainStoreSnapshot = {
+       allPages: [],
+       total: 0
+     };
+     const domainSavedPagesStore = {
+       getSnapshot: vi.fn(() => domainStoreSnapshot),
+       hydrate: vi.fn(async () => domainStoreSnapshot),
+       subscribe: vi.fn(() => () => {}),
+       reset: vi.fn(),
+       ...(overrides.domainSavedPagesStore || {})
+     };
+     const createDomainSavedPagesStoreFn = overrides.createDomainSavedPagesStoreFn || vi.fn(() => domainSavedPagesStore);
      const projectsStore = {
        hydrate: vi.fn().mockResolvedValue({ projects: [] }),
        ...(overrides.projectsStore || {})
@@ -989,6 +1001,7 @@ describe('newtab modules', () => {
        }),
        applyDrawerFilters,
        createProjectSavedPagesStoreFn,
+      createDomainSavedPagesStoreFn,
        windowObj: {
          confirm: vi.fn(() => true),
          alert: vi.fn(),
@@ -1008,10 +1021,12 @@ describe('newtab modules', () => {
        api,
        savedPagesStore,
        projectSavedPagesStore,
+      domainSavedPagesStore,
        projectsStore,
        projectManager,
        savedPagesView,
        createProjectSavedPagesStoreFn,
+      createDomainSavedPagesStoreFn,
        applyDrawerFilters,
        dependencies
      };
@@ -1138,6 +1153,104 @@ describe('newtab modules', () => {
      expect(state.loadedProjectPages.map(page => page.id)).toEqual(['page-1', 'page-2']);
      expect(state.pages.map(page => page.id)).toEqual(['page-1', 'page-2']);
      expect(dependencies.renderDrawerResults).toHaveBeenCalled();
+   });
+
+   it('hydrates domain pages through the merged loadDrawerScope path (parity with project)', async () => {
+     const domainSnapshot = {
+       allPages: [
+         { id: 'd-1', title: 'Example one', domain: 'example.com' },
+         { id: 'd-2', title: 'Example two', domain: 'example.com' }
+       ],
+       total: 2
+     };
+     const {
+       controller,
+       state,
+       api,
+       domainSavedPagesStore,
+       createDomainSavedPagesStoreFn,
+       dependencies
+     } = createDrawerDataHarness({
+       // Production stores the id WITH the "domain:" prefix; the loader
+       // receives the bare domain. Mirror both halves of that contract.
+       state: { selectedDomainId: 'domain:example.com' },
+       domainSavedPagesStore: {
+         getSnapshot: vi.fn(() => ({ allPages: [], total: 0 })),
+         hydrate: vi.fn().mockResolvedValue(domainSnapshot),
+         subscribe: vi.fn(() => () => {})
+       },
+       applyDrawerFilters: vi.fn(query => applySavedPagesDrawerFilters({
+         state,
+         projectManager: { getScopedPages: (dashboard, pages) => pages },
+         savedPagesView: {},
+         query
+       }))
+     });
+
+     await controller.loadDrawerDomainPages('example.com', { query: '  ex  ' });
+     await Promise.resolve();
+
+     expect(createDomainSavedPagesStoreFn).toHaveBeenCalledWith(api, 'example.com', expect.objectContaining({
+       initialFetchLimit: expect.any(Number),
+       prefetchBatchLimit: expect.any(Number)
+     }));
+     expect(domainSavedPagesStore.hydrate).toHaveBeenCalledTimes(1);
+     // Domain view does NOT side-load projects (loadProjectsAlongside: false).
+     expect(state.projects).toEqual([]);
+     expect(dependencies.renderDrawerLoadingState).toHaveBeenCalledWith('Searching pages from this domain…');
+     expect(state.allPages.map(page => page.id)).toEqual(['d-1', 'd-2']);
+     expect(state.loadedProjectPages.map(page => page.id)).toEqual(['d-1', 'd-2']);
+     expect(state.view).toBe('browse');
+     expect(state.hasInitialized).toBe(true);
+   });
+
+   it('loadDrawerScopeForCurrentSelection routes a domain selection to the domain store, not all-pages', async () => {
+     // Regression: forceReload used to branch on project-vs-base only, so a
+     // domain selection silently fell through to loadDrawerBasePages. The
+     // merged scope picker must recognise selectedDomainId and hydrate the
+     // domain store instead.
+     const {
+       controller,
+       savedPagesStore,
+       domainSavedPagesStore
+     } = createDrawerDataHarness({
+       // Stored WITH the "domain:" prefix (nav-row convention).
+       state: { selectedDomainId: 'domain:example.com' },
+       domainSavedPagesStore: {
+         getSnapshot: vi.fn(() => ({ allPages: [], total: 0 })),
+         hydrate: vi.fn().mockResolvedValue({ allPages: [{ id: 'd-1', domain: 'example.com' }], total: 1 }),
+         subscribe: vi.fn(() => () => {})
+       }
+     });
+
+     await controller.loadDrawerScopeForCurrentSelection({ syncUrl: false });
+     await Promise.resolve();
+
+     expect(domainSavedPagesStore.hydrate).toHaveBeenCalledTimes(1);
+     // The all-pages store must NOT have been the one hydrated for this scope.
+     expect(savedPagesStore.hydrate).not.toHaveBeenCalled();
+   });
+
+   it('loadDrawerScopeForCurrentSelection routes an all-pages selection to the base store', async () => {
+     const {
+       controller,
+       savedPagesStore,
+       domainSavedPagesStore
+     } = createDrawerDataHarness({
+       state: { selectedProjectId: null, selectedDomainId: null },
+       savedPagesStore: {
+         getSnapshot: vi.fn(() => ({ allPages: [], total: 0 })),
+         hydrate: vi.fn().mockResolvedValue({ allPages: [{ id: 'a-1' }], total: 1 }),
+         reset: vi.fn(),
+         options: { lazy: true }
+       }
+     });
+
+     await controller.loadDrawerScopeForCurrentSelection({ syncUrl: false });
+     await Promise.resolve();
+
+     expect(savedPagesStore.hydrate).toHaveBeenCalledTimes(1);
+     expect(domainSavedPagesStore.hydrate).not.toHaveBeenCalled();
    });
 
    it('keeps pinned and all-pages sidebar counts tied to the canonical page collection when a project is selected', async () => {

--- a/tests/unit/send-runtime-message.test.js
+++ b/tests/unit/send-runtime-message.test.js
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { sendRuntimeMessage } from '../../src/send-runtime-message.js';
+
+// The helper must work across three load contexts that present different
+// runtime.sendMessage shapes: Chrome without a polyfill (callback form), and
+// Firefox / polyfill-loaded (promise form). These tests pin both paths,
+// including the lastError rejection and the no-runtime guard.
+
+describe('sendRuntimeMessage', () => {
+  it('resolves via the callback path when sendMessage is callback-based (Chrome, no polyfill)', async () => {
+    let capturedMessage = null;
+    let capturedCallback = null;
+    const runtime = {
+      // Chrome shape: returns undefined, delivers via the callback arg.
+      sendMessage(message, callback) {
+        capturedMessage = message;
+        capturedCallback = callback;
+        return undefined;
+      },
+      lastError: null
+    };
+
+    const pending = sendRuntimeMessage(runtime, { action: 'ping' });
+    // The helper should have registered the callback but not yet resolved.
+    expect(capturedMessage).toEqual({ action: 'ping' });
+    expect(typeof capturedCallback).toBe('function');
+
+    // Fire the callback the way chrome.runtime would.
+    capturedCallback({ success: true, ok: true });
+
+    await expect(pending).resolves.toEqual({ success: true, ok: true });
+  });
+
+  it('rejects via the callback path when lastError is set', async () => {
+    const runtime = {
+      sendMessage(_message, callback) {
+        // Defer to mimic the async callback delivery.
+        setTimeout(() => callback(undefined), 0);
+        return undefined;
+      },
+      // lastError is read inside the callback, so set it before delivery.
+      get lastError() { return { message: 'Receiving end does not exist' }; }
+    };
+
+    await expect(sendRuntimeMessage(runtime, { action: 'x' }))
+      .rejects.toThrow('Receiving end does not exist');
+  });
+
+  it('resolves via the promise path when sendMessage returns a thenable (Firefox / polyfill)', async () => {
+    const runtime = {
+      // Firefox/polyfill shape: ignores the callback, returns a promise.
+      sendMessage(message, _callback) {
+        return Promise.resolve({ success: true, echoed: message });
+      },
+      lastError: null
+    };
+
+    await expect(sendRuntimeMessage(runtime, { action: 'signIn' }))
+      .resolves.toEqual({ success: true, echoed: { action: 'signIn' } });
+  });
+
+  it('rejects via the promise path when the returned promise rejects', async () => {
+    const runtime = {
+      sendMessage() {
+        return Promise.reject(new Error('boom'));
+      },
+      lastError: null
+    };
+
+    await expect(sendRuntimeMessage(runtime, { action: 'x' })).rejects.toThrow('boom');
+  });
+
+  it('rejects with a clear message when no runtime is available', async () => {
+    await expect(sendRuntimeMessage(null, { action: 'x' }))
+      .rejects.toThrow('Browser runtime API not available');
+    await expect(sendRuntimeMessage({}, { action: 'x' }))
+      .rejects.toThrow('Browser runtime API not available');
+  });
+
+  it('rejects when sendMessage throws synchronously', async () => {
+    const runtime = {
+      sendMessage() {
+        throw new Error('extension context invalidated');
+      }
+    };
+
+    await expect(sendRuntimeMessage(runtime, { action: 'x' }))
+      .rejects.toThrow('extension context invalidated');
+  });
+
+  // Regression for the auth-menu latent bug: before unification, signIn did
+  // `await runtime.sendMessage(...)` directly. On a callback-based runtime
+  // (Chrome before the polyfill loads) sendMessage returns undefined, so the
+  // await resolved to undefined and signIn treated it as success. The shared
+  // helper must correctly resolve via the callback instead.
+  it('does NOT resolve to undefined on a callback-based runtime (auth-menu regression)', async () => {
+    let callback = null;
+    const runtime = {
+      sendMessage(_message, cb) { callback = cb; return undefined; },
+      lastError: null
+    };
+
+    const pending = sendRuntimeMessage(runtime, { action: 'signIn' });
+    callback({ success: true, user: { uid: 'u1' } });
+
+    const result = await pending;
+    expect(result).toEqual({ success: true, user: { uid: 'u1' } });
+    expect(result).not.toBeUndefined();
+  });
+});

--- a/tests/unit/toolbar-popup.test.js
+++ b/tests/unit/toolbar-popup.test.js
@@ -88,7 +88,10 @@ describe('toolbar popup', () => {
 
     document.querySelector('.toolbar-popup-project-btn')?.click();
     await vi.waitFor(() => {
-      expect(sendMessage).toHaveBeenNthCalledWith(2, {
+      // The shared sendRuntimeMessage helper passes (message, callback); assert
+      // on the message argument of the second call rather than the whole call
+      // shape, since the callback is an internal detail.
+      expect(sendMessage.mock.calls[1]?.[0]).toEqual({
         action: 'saveCurrentPage',
         projectId: 'project-1'
       });


### PR DESCRIPTION
## Summary

Addresses every architectural finding from the front-end code review. Two latent bugs fixed along the way. No user-visible behavior change except those two fixes (both make previously-broken paths work correctly).

## What changed

**Drawer architecture (commits 1–2)**
- `newtab-drawer-state.js` is now the single mutation owner — all ~30 state fields write through named functions there, locked by a guard test. Previously mutated by reference from closures across 5 files.
- Three drifted load paths (`loadDrawerBasePages`/`Project`/`Domain`) merged into one `loadDrawerScope` driven by a per-scope config table.
- Deleted dead re-export `newtab-drawer-controller.js` (imported by nobody).
- Slimmed the DI seam from 11 to 8 overrides (dropped 3 pure-composition factories no test asserts on).

**Cross-surface helpers (commit 3)**
- Extracted `el()`/`queryId()` into `shared-ui-helpers.js` (3 drifted copies → 1).
- Unified `applySessionRotation` (2 copies → 1 export in `api-core.js`).
- Unified `sendRuntime` — one helper (`send-runtime-message.js`) using the only strategy that works in all three load contexts (toolbar popup has no polyfill → Chrome callback; newtab async-racy; settled → promise).
- Removed dead duplicate guard in `warm-cache-list-store.js` `hydrate()`.

## Latent bugs fixed
1. **`forceReload` domain routing** — branched on project-vs-base only, so a domain selection silently routed to all-pages. Now picks all/project/domain correctly via `loadDrawerScopeForCurrentSelection`. (Also caught a related `selectedDomainId` prefix bug while writing the test.)
2. **`auth-menu` pre-polyfill sign-in** — `await runtime.sendMessage(...)` resolves to `undefined` on a callback-based runtime (Chrome before polyfill loads) and was treated as success. The shared helper resolves correctly via the callback path. Pinned by a regression test.

## Test plan
- [x] `just check` green — 645 tests pass (was 621; +24 new), lint clean, bundles build, no CSP violations
- [x] New ownership guard test locks the single-writer invariant
- [x] New `send-runtime-message.test.js` covers the callback form (the gap — no prior test exercised the form actually running in the toolbar popup in production)
- [x] New tests pin the forceReload domain fix and the merged load path

## Non-goals
Realtime no-reconnect cliff left deliberately (product decision, not cleanup). Polyfill loading mechanism unchanged.

🤖 Generated with [ZCode](https://zcode.ai)