### PR TITLE
arch: per-surface cache, shared transport, realtime bfcache fix, API consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,13 +67,36 @@ The author runs the extension for local development in **Brave** (Chromium), loa
 
 - `src/newtab.js` - main new-tab UI, favorites, saved pages drawer
 - `src/project-manager.js` - project navigation and membership editing
-- `src/api.js` / `src/api-pages.js` - API layer
-- `src/cache-manager.js` - browser storage cache
+- `src/api.js` / `src/api-pages.js` - API layer (facade composed from `applyX(API)` mixins)
+- `src/api-core.js` - core API runtime: auth, transport delegation, per-surface cache routing
+- `src/api-transport.js` - single authenticated `fetch` shared by the facade and the background SW (URL/params/Bearer/error/rotation in one place)
+- `src/cache-manager.js` - browser storage cache (one instance per surface)
+- `src/cache-keys.js` - per-surface cache prefixes (`savedPages_cache`, `projects_cache`, `domains_cache`) and one-time key migrations
 - `src/warm-cache-list-store.js` - local-first paginated list syncing
-- `src/background.js` - toolbar save and auth integration
+- `src/projects-store.js` - `WarmCacheListStore` subclass for projects (routes its warm cache through the projects surface)
+- `src/realtime-client.js` - single SSE connection per open new-tab page (idempotent `connect()`, no auto-reconnect; bfcache restore reconnects via `pageshow`)
+- `src/background.js` - toolbar save and auth integration (composes `api-transport.js`; its own `CacheManager` instance for the toolbar's projects warm cache)
 - `src/data-sync-centre.js` - consolidated Import / Export / Browser-sync modal
 - `src/bookmark-import.js` / `src/bookmark-export.js` - pure CSV/HTML/JSON parsers and serializers
 - `src/bookmark-mirror.js` - server-to-browser bookmark sync (reconcile, removeMirror)
+
+### Per-surface cache architecture
+
+The facade lazily constructs **three `CacheManager` instances**, one per data surface, each with its own storage prefix so a mutation on one surface invalidates narrowly without dropping the others:
+
+| Surface | CacheManager getter | Prefix | Methods |
+|---|---|---|---|
+| Saved pages | `API.cacheManager` | `savedPages_cache` | `getCachedPages` / `setCachedPages` / `invalidateCache` / `getCachedPagesState` |
+| Projects | `API.projectsCacheManager` | `projects_cache` | `getProjectsCachedPages` / `setProjectsCachedPages` / `invalidateProjectsCache` / `getProjectsCachedPagesState` |
+| Domains | `API.domainsCacheManager` | `domains_cache` | `getDomainsCachedPages` / `setDomainsCachedPages` / `invalidateDomainsCache` / `getDomainsCachedPagesState` |
+
+Mutation invalidation is scoped to the surfaces a write can actually change: `createProject`/`updateProject` invalidate only projects; `deletePage`/`updatePage` invalidate saved-pages + domains (classification/title shifts affect domain counts); `pinPage` invalidates only saved-pages; `addPageToProject`/`removePageFromProject` invalidate both projects and saved-pages (membership vs `project_ids`). `API.invalidateAllCaches()` exists for the user-facing "reload from server" affordance. The background SW (which doesn't load the facade) uses the storage-direct helpers in `saved-pages-cache.js` (`invalidateToolbarSaveCaches` for save + realtime relay).
+
+The cached-read flow (`API._getCachedOrFreshList`) is shared across all three surfaces. The cache-scope builders (`_buildListCacheScope`, `buildProjectsCacheScope`, `buildDomainsCacheScope`) are intentionally separate — each surface has its own query dimensions (lists carry sort/cursor/projectId; projects carry includeArchived; domains carry none), so forcing them through one builder would add parameters most surfaces ignore.
+
+### Realtime lifecycle
+
+One SSE stream per open new-tab page. `RealtimeClient.connect()` is idempotent (a second call while a stream is open is a no-op, so a bfcache `pageshow` reconnect can't orphan the existing `AbortController`). There is **no mid-stream token refresh** and **no auto-reconnect** — a dropped stream toasts once and the user refreshes to re-establish. The newtab page registers persistent `pagehide`/`pageshow` listeners (not `once`) so a bfcache restore reconnects the stream and a second navigation away still tears it down.
 
 ### Two-repo note
 

--- a/src/api-core.js
+++ b/src/api-core.js
@@ -251,7 +251,21 @@ export function applyApiCore(API, dependencies = {}) {
       };
     },
 
+    // Attach a { fromCache } meta flag to a response. Lists return a plain
+    // object ({ pages, pagination }) so meta is merged in via spread; projects
+    // and domains return Arrays, where spread would destroy array-ness
+    // (Array.isArray({...arr}) === false), so those use a non-enumerable
+    // defineProperty instead. Either way, consumers read meta?.fromCache.
     _withCacheMetadata(response, fromCache) {
+      if (Array.isArray(response)) {
+        Object.defineProperty(response, 'meta', {
+          value: { ...(response.meta || {}), fromCache },
+          configurable: true,
+          enumerable: false,
+          writable: true
+        });
+        return response;
+      }
       return {
         ...response,
         meta: {
@@ -263,6 +277,52 @@ export function applyApiCore(API, dependencies = {}) {
 
     async parseErrorResponse(response) {
       return parseErrorResponse(response);
+    },
+
+    // Shared cached-read flow used by the saved-pages, projects, and domains
+    // surfaces. Each surface inlined its own version of this 5-step dance
+    // (build scope → check skipCache → read cache → fetch+normalize → write
+    // cache → tag meta); this factors it into one place. Callers pass:
+    //   - cacheScope: the scope key for the surface's own CacheManager
+    //   - readCache / writeCache: bound to the surface's CM methods
+    //   - fetcher: () => Promise<raw backend data>
+    //   - normalize: (raw) => value-to-cache-and-return (only called on a
+    //     fresh fetch; cache hits return the stored value as-is, since it was
+    //     normalized before being written)
+    //   - mockFetcher: standalone-mode fallback (options) => value
+    //   - context: label for telemetry/logging
+    //   - options: the caller's options (carries skipCache etc.)
+    async _getCachedOrFreshList({
+      cacheScope,
+      readCache,
+      writeCache,
+      fetcher,
+      normalize,
+      mockFetcher,
+      context,
+      options = {}
+    }) {
+      if (this.isExtension) {
+        if (!options.skipCache) {
+          const cached = await readCache(cacheScope);
+          if (cached) {
+            return this._withCacheMetadata(cached, true);
+          }
+        }
+
+        return this._executeWithErrorHandling(
+          async () => {
+            const data = await fetcher();
+            const normalized = normalize(data);
+            await writeCache(normalized, cacheScope);
+            return this._withCacheMetadata(normalized, false);
+          },
+          context,
+          { options }
+        );
+      }
+
+      return this._withCacheMetadata(mockFetcher(options), false);
     },
 
     async getIdToken() {

--- a/src/api-core.js
+++ b/src/api-core.js
@@ -9,6 +9,10 @@ import {
   getStorageAPI as defaultGetStorageAPI
 } from './config.js';
 import {
+  PROJECTS_CACHE_PREFIX,
+  DOMAINS_CACHE_PREFIX
+} from './cache-keys.js';
+import {
   getSessionToken,
   getCurrentUserId as getSessionUserId,
   setSession
@@ -73,9 +77,17 @@ export function applyApiCore(API, dependencies = {}) {
   } = dependencies;
 
   API._cacheManager = null;
+  API._projectsCacheManager = null;
+  API._domainsCacheManager = null;
   API._lastKnownUserId = undefined;
   API.LAST_KNOWN_USER_KEY = 'saveit_lastKnownUser';
 
+  // Each data surface gets its own CacheManager with its own storage prefix, so
+  // a mutation on one surface (e.g. a project edit) can invalidate narrowly
+  // without dropping the others (saved pages, domains). This satisfies the
+  // caching-redux rules "cache keys match query shape" (#6) and "invalidate
+  // narrowly, recover broadly" (#8). The default cacheManager is the
+  // saved-pages surface; projects and domains get their own below.
   Object.defineProperty(API, 'cacheManager', {
     configurable: true,
     enumerable: true,
@@ -90,6 +102,42 @@ export function applyApiCore(API, dependencies = {}) {
         );
       }
       return this._cacheManager;
+    }
+  });
+
+  Object.defineProperty(API, 'projectsCacheManager', {
+    configurable: true,
+    enumerable: true,
+    get() {
+      if (!this._projectsCacheManager && this.isExtension) {
+        this._projectsCacheManager = new cacheManagerClass(
+          () => this.getCurrentUserId(),
+          () => this.getStorage(),
+          {
+            getBootstrapUserId: () => this.getLastKnownUserId(),
+            keyPrefix: PROJECTS_CACHE_PREFIX
+          }
+        );
+      }
+      return this._projectsCacheManager;
+    }
+  });
+
+  Object.defineProperty(API, 'domainsCacheManager', {
+    configurable: true,
+    enumerable: true,
+    get() {
+      if (!this._domainsCacheManager && this.isExtension) {
+        this._domainsCacheManager = new cacheManagerClass(
+          () => this.getCurrentUserId(),
+          () => this.getStorage(),
+          {
+            getBootstrapUserId: () => this.getLastKnownUserId(),
+            keyPrefix: DOMAINS_CACHE_PREFIX
+          }
+        );
+      }
+      return this._domainsCacheManager;
     }
   });
 
@@ -269,6 +317,79 @@ export function applyApiCore(API, dependencies = {}) {
     async cleanupLegacyCache() {
       if (!this.isExtension) return;
       return await this.cacheManager.cleanupLegacyCache();
+    },
+
+    // --- projects surface cache (own prefix: PROJECTS_CACHE_PREFIX) ---
+    async getProjectsCachedPages(scope = {}, options = {}) {
+      if (!this.isExtension) return null;
+      return await this.projectsCacheManager.getCachedPages(scope, options);
+    },
+
+    async getProjectsCachedPagesState(scope = {}, options = {}) {
+      if (!this.isExtension) {
+        return {
+          status: 'empty',
+          response: null,
+          error: null,
+          ageMs: null,
+          timestamp: null,
+          reason: 'not-extension',
+          usable: false
+        };
+      }
+      return await this.projectsCacheManager.getCachedPagesState(scope, options);
+    },
+
+    async setProjectsCachedPages(response, scope = {}) {
+      if (!this.isExtension) return;
+      return await this.projectsCacheManager.setCachedPages(response, scope);
+    },
+
+    async invalidateProjectsCache(scope = null) {
+      if (!this.isExtension) return;
+      return await this.projectsCacheManager.invalidateCache(scope);
+    },
+
+    // --- domains surface cache (own prefix: DOMAINS_CACHE_PREFIX) ---
+    async getDomainsCachedPages(scope = {}, options = {}) {
+      if (!this.isExtension) return null;
+      return await this.domainsCacheManager.getCachedPages(scope, options);
+    },
+
+    async getDomainsCachedPagesState(scope = {}, options = {}) {
+      if (!this.isExtension) {
+        return {
+          status: 'empty',
+          response: null,
+          error: null,
+          ageMs: null,
+          timestamp: null,
+          reason: 'not-extension',
+          usable: false
+        };
+      }
+      return await this.domainsCacheManager.getCachedPagesState(scope, options);
+    },
+
+    async setDomainsCachedPages(response, scope = {}) {
+      if (!this.isExtension) return;
+      return await this.domainsCacheManager.setCachedPages(response, scope);
+    },
+
+    async invalidateDomainsCache(scope = null) {
+      if (!this.isExtension) return;
+      return await this.domainsCacheManager.invalidateCache(scope);
+    },
+
+    // Invalidate every surface cache. Used by the user-facing "reload from
+    // server" affordance, where the intent is to bust everything and re-fetch.
+    async invalidateAllCaches() {
+      if (!this.isExtension) return;
+      await Promise.all([
+        this.invalidateCache(),
+        this.invalidateProjectsCache(),
+        this.invalidateDomainsCache()
+      ]);
     },
 
     async _executeWithErrorHandling(operation, context, metadata = {}) {

--- a/src/api-core.js
+++ b/src/api-core.js
@@ -1,8 +1,7 @@
 // api-core.js - Core API runtime, auth, transport, and cache helpers
 
-// api-core.js - Core API runtime, auth, transport, and cache helpers
-
 import { CacheManager } from './cache-manager.js';
+import { requestWithAuth } from './api-transport.js';
 import {
   CONFIG as defaultConfig,
   getBrowserRuntime as defaultGetBrowserRuntime,
@@ -403,40 +402,21 @@ export function applyApiCore(API, dependencies = {}) {
     },
 
     async _requestWithAuth(endpoint, params = null, options = {}) {
-      const idToken = await this.getIdToken();
-
-      let url = endpoint.startsWith('http') ? endpoint : `${config.cloudFunctionUrl}${endpoint}`;
-      if (params) {
-        const searchParams = params instanceof URLSearchParams
-          ? params
-          : new URLSearchParams(params);
-        url = `${url}?${searchParams}`;
-      }
-
-      // eslint-disable-next-line no-unused-vars
-      const { headers: _, ...fetchOptions } = options;
-
-      const response = await fetch(url, {
-        ...fetchOptions,
+      // Delegate to the shared transport (api-transport.js) so the facade and
+      // the background SW use one authenticated-fetch implementation. Facade
+      // callers pre-serialize `body` (a JSON string) and may set Content-Type
+      // in headers; both are passed through verbatim.
+      return await requestWithAuth({
+        url: endpoint,
+        baseUrl: config.cloudFunctionUrl,
+        params,
         method: options.method || 'GET',
-        headers: {
-          'Authorization': `Bearer ${idToken}`,
-          ...options.headers
-        }
+        body: options.body,
+        headers: options.headers,
+        getIdToken: () => this.getIdToken(),
+        onRotation: (response) => this._applySessionRotation(response),
+        parseError: (response) => this.parseErrorResponse(response)
       });
-
-      if (!response.ok) {
-        const errorMessage = await this.parseErrorResponse(response);
-        const error = new Error(errorMessage);
-        error.status = response.status;
-        throw error;
-      }
-
-      // Sliding session refresh: store a rotated token if the backend
-      // returned one. Best-effort — does not affect the current response.
-      await this._applySessionRotation(response);
-
-      return response;
     },
 
     async _applySessionRotation(response) {

--- a/src/api-pages-domains.js
+++ b/src/api-pages-domains.js
@@ -34,7 +34,7 @@ export function applyApiDomains(API) {
           async () => {
             const cacheScope = buildDomainsCacheScope();
             if (!options.skipCache) {
-              const cached = await this.getCachedPages(cacheScope);
+              const cached = await this.getDomainsCachedPages(cacheScope);
               if (cached) {
                 return withDomainsCacheMetadata(cached, true);
               }
@@ -42,7 +42,7 @@ export function applyApiDomains(API) {
 
             const response = await this._fetchWithAuth('', { domains: 'true' });
             const domains = Array.isArray(response?.domains) ? response.domains : [];
-            await this.setCachedPages(domains, cacheScope);
+            await this.setDomainsCachedPages(domains, cacheScope);
             return withDomainsCacheMetadata(domains, false);
           },
           'getDomains',

--- a/src/api-pages-domains.js
+++ b/src/api-pages-domains.js
@@ -9,17 +9,6 @@ function buildDomainsCacheScope() {
   return { surface: 'domains' };
 }
 
-function withDomainsCacheMetadata(domains, fromCache) {
-  Object.defineProperty(domains, 'meta', {
-    value: { fromCache },
-    configurable: true,
-    enumerable: false,
-    writable: true
-  });
-
-  return domains;
-}
-
 export function applyApiDomains(API) {
   Object.assign(API, {
     /**
@@ -30,27 +19,19 @@ export function applyApiDomains(API) {
      */
     async getDomains(options = {}) {
       if (this.isExtension) {
-        return this._executeWithErrorHandling(
-          async () => {
-            const cacheScope = buildDomainsCacheScope();
-            if (!options.skipCache) {
-              const cached = await this.getDomainsCachedPages(cacheScope);
-              if (cached) {
-                return withDomainsCacheMetadata(cached, true);
-              }
-            }
-
-            const response = await this._fetchWithAuth('', { domains: 'true' });
-            const domains = Array.isArray(response?.domains) ? response.domains : [];
-            await this.setDomainsCachedPages(domains, cacheScope);
-            return withDomainsCacheMetadata(domains, false);
-          },
-          'getDomains',
-          { options }
-        );
+        return this._getCachedOrFreshList({
+          cacheScope: buildDomainsCacheScope(),
+          readCache: (scope) => this.getDomainsCachedPages(scope),
+          writeCache: (value, scope) => this.setDomainsCachedPages(value, scope),
+          fetcher: () => this._fetchWithAuth('', { domains: 'true' }),
+          normalize: (response) => Array.isArray(response?.domains) ? response.domains : [],
+          mockFetcher: getStandaloneDomains,
+          context: 'getDomains',
+          options
+        });
       }
 
-      return withDomainsCacheMetadata(getStandaloneDomains(options), false);
+      return this._withCacheMetadata(getStandaloneDomains(options), false);
     }
   });
 

--- a/src/api-pages-import.js
+++ b/src/api-pages-import.js
@@ -31,8 +31,13 @@ export function applyApiImport(API) {
               body: JSON.stringify({ bulk: true, projectId, bookmarks })
             });
 
-            // One cache invalidation for the whole batch, not per item.
-            await this.invalidateCache();
+            // One cache invalidation per affected surface for the whole batch,
+            // not per item. Bulk imports create saved pages and may assign them
+            // to a project (options.projectId), so both surfaces can be stale.
+            await Promise.all([
+              this.invalidateCache(),
+              this.invalidateProjectsCache()
+            ]);
             return response;
           },
           'bulkImportBookmarks',

--- a/src/api-pages-lists.js
+++ b/src/api-pages-lists.js
@@ -126,33 +126,23 @@ async function getCachedOrFreshList(API, {
     skipCache: options.skipCache || false
   });
 
-  if (API.isExtension) {
-    const cacheScope = API._buildListCacheScope(surface, options);
-
-    if (!options.skipCache) {
-      const cached = await API.getCachedPages(cacheScope);
-      if (cached) {
-        debug(`[${context}] Returning cached data:`, {
-          count: cached.pages?.length,
-          total: cached.pagination?.total
-        });
-        return API._withCacheMetadata(cached, true);
-      }
-    }
-
-    return API._executeWithErrorHandling(
-      async () => {
-        const data = await fetcher(options);
-        const normalized = normalizePagesResponse(data, context);
-        await API.setCachedPages(normalized, cacheScope);
-        return API._withCacheMetadata(normalized, false);
-      },
-      context,
-      { options }
-    );
-  }
-
-  return API._withCacheMetadata(mockFetcher(options), false);
+  // Delegate the cache-or-fetch dance to the shared helper (api-core
+  // _getCachedOrFreshList). Lists carry a `surface` (dashboard / favorites)
+  // and a sort/cursor/projectId scope, and normalize backend responses into
+  // the { pages, pagination, meta } shape. The cache stores already-
+  // normalized payloads, so normalize is a no-op on cache hits (the data
+  // already has .pages) and a real normalization on fresh fetches.
+  const cacheScope = API._buildListCacheScope(surface, options);
+  return API._getCachedOrFreshList({
+    cacheScope,
+    readCache: (scope) => API.getCachedPages(scope),
+    writeCache: (value, scope) => API.setCachedPages(value, scope),
+    fetcher: () => fetcher(options),
+    normalize: (data) => normalizePagesResponse(data, context),
+    mockFetcher,
+    context,
+    options
+  });
 }
 
 async function headListFreshness(API, {

--- a/src/api-pages-page-actions.js
+++ b/src/api-pages-page-actions.js
@@ -14,7 +14,12 @@ export function applyApiPageActions(API) {
               method: 'DELETE',
             });
 
-            await this.invalidateCache();
+            // Deleting a page shifts its domain's count, so invalidate the
+            // domains cache alongside the saved-pages cache.
+            await Promise.all([
+              this.invalidateCache(),
+              this.invalidateDomainsCache()
+            ]);
             return response;
           },
           'deletePage',
@@ -37,7 +42,12 @@ export function applyApiPageActions(API) {
               body: JSON.stringify({ id, ...updates })
             });
 
-            await this.invalidateCache();
+            // An update can change classification/title (which feeds the
+            // domains list), so invalidate domains alongside saved pages.
+            await Promise.all([
+              this.invalidateCache(),
+              this.invalidateDomainsCache()
+            ]);
             return response;
           },
           'updatePage',
@@ -60,6 +70,8 @@ export function applyApiPageActions(API) {
               body: JSON.stringify({ id, pinned })
             });
 
+            // Pinning doesn't change domain membership, so only the saved-pages
+            // surface (which carries the pinned flag) needs invalidation.
             await this.invalidateCache();
             return response;
           },

--- a/src/api-pages-projects.js
+++ b/src/api-pages-projects.js
@@ -36,17 +36,6 @@ function buildProjectsCacheScope(options = {}) {
   };
 }
 
-function withProjectsCacheMetadata(projects, fromCache) {
-  Object.defineProperty(projects, 'meta', {
-    value: { fromCache },
-    configurable: true,
-    enumerable: false,
-    writable: true
-  });
-
-  return projects;
-}
-
 function buildCreateProjectPayload(project) {
   const payload = {
     name: project.name?.trim()
@@ -89,29 +78,21 @@ export function applyApiProjects(API) {
   Object.assign(API, {
     async getProjects(options = {}) {
       if (this.isExtension) {
-        return this._executeWithErrorHandling(
-          async () => {
-            const cacheScope = buildProjectsCacheScope(options);
-            if (!options.skipCache) {
-              const cached = await this.getProjectsCachedPages(cacheScope);
-              if (cached) {
-                return withProjectsCacheMetadata(normalizeProjectsResponse(cached), true);
-              }
-            }
+        const params = {};
+        if (options.includeArchived !== undefined) {
+          params.includeArchived = String(options.includeArchived);
+        }
 
-            const params = {};
-            if (options.includeArchived !== undefined) {
-              params.includeArchived = String(options.includeArchived);
-            }
-
-            const response = await this._fetchWithAuth('/projects', params);
-            const normalized = normalizeProjectsResponse(response);
-            await this.setProjectsCachedPages(normalized, cacheScope);
-            return withProjectsCacheMetadata(normalized, false);
-          },
-          'getProjects',
-          { options }
-        );
+        return this._getCachedOrFreshList({
+          cacheScope: buildProjectsCacheScope(options),
+          readCache: (scope) => this.getProjectsCachedPages(scope),
+          writeCache: (value, scope) => this.setProjectsCachedPages(value, scope),
+          fetcher: () => this._fetchWithAuth('/projects', params),
+          normalize: normalizeProjectsResponse,
+          mockFetcher: getStandaloneProjects,
+          context: 'getProjects',
+          options
+        });
       }
 
       return getStandaloneProjects(options);

--- a/src/api-pages-projects.js
+++ b/src/api-pages-projects.js
@@ -93,7 +93,7 @@ export function applyApiProjects(API) {
           async () => {
             const cacheScope = buildProjectsCacheScope(options);
             if (!options.skipCache) {
-              const cached = await this.getCachedPages(cacheScope);
+              const cached = await this.getProjectsCachedPages(cacheScope);
               if (cached) {
                 return withProjectsCacheMetadata(normalizeProjectsResponse(cached), true);
               }
@@ -106,7 +106,7 @@ export function applyApiProjects(API) {
 
             const response = await this._fetchWithAuth('/projects', params);
             const normalized = normalizeProjectsResponse(response);
-            await this.setCachedPages(normalized, cacheScope);
+            await this.setProjectsCachedPages(normalized, cacheScope);
             return withProjectsCacheMetadata(normalized, false);
           },
           'getProjects',
@@ -130,7 +130,7 @@ export function applyApiProjects(API) {
               body: JSON.stringify(payload)
             });
 
-            await this.invalidateCache();
+            await this.invalidateProjectsCache();
             return response;
           },
           'createProject',
@@ -154,7 +154,7 @@ export function applyApiProjects(API) {
               body: JSON.stringify(payload)
             });
 
-            await this.invalidateCache();
+            await this.invalidateProjectsCache();
             return response;
           },
           'updateProject',
@@ -177,7 +177,12 @@ export function applyApiProjects(API) {
               body: JSON.stringify({ pageId })
             });
 
-            await this.invalidateCache();
+            // Adding a page to a project changes both the projects cache
+            // (membership) and the saved-pages cache (the page's project_ids).
+            await Promise.all([
+              this.invalidateProjectsCache(),
+              this.invalidateCache()
+            ]);
             return response;
           },
           'addPageToProject',
@@ -198,7 +203,11 @@ export function applyApiProjects(API) {
               { method: 'DELETE' }
             );
 
-            await this.invalidateCache();
+            // Removing a page from a project changes both surfaces — see addPageToProject.
+            await Promise.all([
+              this.invalidateProjectsCache(),
+              this.invalidateCache()
+            ]);
             return response;
           },
           'removePageFromProject',

--- a/src/api-transport.js
+++ b/src/api-transport.js
@@ -1,0 +1,118 @@
+// api-transport.js — single authenticated fetch implementation shared by the
+// API facade (api-core.js) and the background service worker (background.js).
+//
+// Previously the URL-building, Bearer-header, error-parsing, and session-
+// rotation logic was duplicated across api-core._requestWithAuth and
+// background.fetchBackgroundApi. Any change to the transport contract (a new
+// header, retry policy, token-refresh tweak) had to be made in both places and
+// the two auth entry points could drift. This module is the one implementation;
+// both call sites compose it with their own token getter and rotation callback.
+//
+// Pure / dependency-free: safe for the background to import without pulling in
+// the full pages/search facade. parseErrorResponse and applySessionRotation
+// (from api-core.js) are injected by callers rather than imported here, to keep
+// the dependency arrow one-way (api-transport has no upstream imports).
+
+/**
+ * Build the full request URL, appending query params when present.
+ * Matches the URLSearchParams behaviour previously inlined in both call sites.
+ *
+ * @param {object} args
+ * @param {string} args.url - Absolute URL, or a path resolved against baseUrl.
+ * @param {string} args.baseUrl - Base URL prepended when url is relative.
+ * @param {object|URLSearchParams|null} [args.params] - Query params.
+ * @returns {string}
+ */
+function buildRequestUrl({ url, baseUrl, params }) {
+  const fullUrl = url.startsWith('http') ? url : `${baseUrl}${url}`;
+  if (!params) return fullUrl;
+
+  // Accept either a URLSearchParams instance or a plain object. Filter
+  // null/undefined from plain objects — new URLSearchParams({k:null}) throws
+  // in most environments, and the background path has always skipped them.
+  let searchParams;
+  if (params instanceof URLSearchParams) {
+    searchParams = params;
+  } else {
+    searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null) {
+        searchParams.set(key, String(value));
+      }
+    }
+  }
+  const qs = searchParams.toString();
+  return qs ? `${fullUrl}?${qs}` : fullUrl;
+}
+
+/**
+ * Single authenticated fetch. Used by the API facade and the background SW.
+ *
+ * @param {object} args
+ * @param {string} args.url - Absolute URL or path (resolved against baseUrl).
+ * @param {string} args.baseUrl - Cloud Function base URL.
+ * @param {object|URLSearchParams|null} [args.params] - Query-string params.
+ *   GET requests rely on these; a request body is silently dropped by the
+ *   backend, so params are the only way to pass options on a GET.
+ * @param {string} [args.method='GET']
+ * @param {string} [args.body] - Pre-serialized request body (a JSON string).
+ *   Both call sites serialize before calling, so this is passed through
+ *   verbatim; Content-Type: application/json is set when a body is present.
+ * @param {object} [args.headers] - Extra headers (Authorization is set here).
+ * @param {function(): Promise<string|null>} args.getIdToken - Resolves the
+ *   bearer token (facade uses the session token; background uses signIn).
+ * @param {function(Response): Promise<void>|void} [args.onRotation] - Called
+ *   with the response so the caller can read rotated session headers.
+ * @param {function(Response): Promise<string>} [args.parseError] - Maps a
+ *   non-ok Response to a human-readable error message. Defaults to a simple
+ *   HTTP-status string; callers inject parseErrorResponse for full parity.
+ * @returns {Promise<Response>} The raw fetch Response. Throws on !ok with
+ *   error.status attached, matching the prior api-core behaviour.
+ */
+export async function requestWithAuth({
+  url,
+  baseUrl,
+  params = null,
+  method = 'GET',
+  body = undefined,
+  headers = {},
+  getIdToken,
+  onRotation,
+  parseError = null
+}) {
+  const idToken = await getIdToken();
+
+  const requestHeaders = {
+    ...(idToken ? { Authorization: `Bearer ${idToken}` } : {}),
+    ...headers
+  };
+  if (body !== undefined) {
+    requestHeaders['Content-Type'] = requestHeaders['Content-Type'] || 'application/json';
+  }
+
+  const response = await fetch(buildRequestUrl({ url, baseUrl, params }), {
+    method,
+    headers: requestHeaders,
+    ...(body !== undefined ? { body } : {})
+  });
+
+  if (!response.ok) {
+    const errorMessage = parseError
+      ? await parseError(response)
+      : `HTTP ${response.status}`;
+    const error = new Error(errorMessage);
+    error.status = response.status;
+    throw error;
+  }
+
+  // Sliding session refresh: the backend rotates the token inline via response
+  // headers once it crosses the refresh threshold. Best-effort — a failure here
+  // does not invalidate the request that carried the rotation.
+  if (onRotation) {
+    await onRotation(response);
+  }
+
+  return response;
+}
+
+export { buildRequestUrl };

--- a/src/background.js
+++ b/src/background.js
@@ -4,14 +4,14 @@ import { createBackgroundAuth } from './background-auth.js';
 import { getCurrentUserId as getSessionUserId } from './session-store.js';
 import { CacheManager } from './cache-manager.js';
 import { ProjectsStore } from './projects-store.js';
-import { invalidateSavedPagesCacheStorage } from './saved-pages-cache.js';
+import { invalidateToolbarSaveCaches } from './saved-pages-cache.js';
 import { reconcile, mirrorSavedPage, removeMirror } from './bookmark-mirror.js';
 import { getMirrorState, setMirrorEnabled } from './bookmark-mirror-settings.js';
 import { createLogger, getSafePageContext } from './telemetry.js';
 import { capturePageContent } from './page-capture-injector.js';
 import { addPendingSave } from './pending-saves.js';
 import { applySessionRotation, parseErrorResponse } from './api-core.js';
-import { PROJECTS_CACHE_PREFIX, migrateProjectsCacheKeys } from './cache-keys.js';
+import { PROJECTS_CACHE_PREFIX, migrateProjectsCacheKeys, migrateDomainsCacheKeys } from './cache-keys.js';
 
 const logger = createLogger('background');
 const authLogger = createLogger('background-auth');
@@ -181,10 +181,17 @@ const toolbarProjectsStore = new ProjectsStore({
     const projects = await fetchBackgroundApi('/projects');
     return Array.isArray(projects) ? projects : [];
   },
-  getCachedPages(scope, options) {
+  // ProjectsStore reads/writes its warm cache via the projects-surface methods
+  // (PROJECTS_CACHE_PREFIX) so it doesn't collide with the saved-pages cache.
+  // The toolbar has its own CacheManager instance for the projects surface
+  // because the full API facade isn't loaded in the background.
+  getProjectsCachedPages(scope, options) {
     return toolbarProjectsCacheManager.getCachedPages(scope, options);
   },
-  setCachedPages(projects, scope) {
+  getProjectsCachedPagesState(scope, options) {
+    return toolbarProjectsCacheManager.getCachedPagesState(scope, options);
+  },
+  setProjectsCachedPages(projects, scope) {
     return toolbarProjectsCacheManager.setCachedPages(projects, scope);
   }
 });
@@ -340,6 +347,8 @@ browserApi.runtime.onInstalled?.addListener(() => {
     // Evict projects keys written under the old savedPages_cache prefix before
     // projects got their own namespace. No-op after the first run.
     await migrateProjectsCacheKeys(browserApi.storage.local);
+    // Same one-time eviction for domains, now that domains have their own prefix.
+    await migrateDomainsCacheKeys(browserApi.storage.local);
   })();
 });
 
@@ -454,7 +463,7 @@ async function savePageFromTab(tab, { projectId = null } = {}) {
   }
 
   try {
-    const cacheKeysRemoved = await invalidateSavedPagesCacheStorage(browserApi.storage.local);
+    const cacheKeysRemoved = await invalidateToolbarSaveCaches(browserApi.storage.local);
     logger.log('Cache invalidated after save', {
       cacheKeysRemoved
     });
@@ -642,9 +651,13 @@ browserApi.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // reconciliation or newtab reload clears it via onOptimisticReconciled.
     (async () => {
       try {
-        await invalidateSavedPagesCacheStorage(browserApi.storage.local);
-        logger.log('Realtime enrichment relay; invalidated saved-pages cache', {
-          pageId: message.pageId || null
+        // Invalidate saved-pages and domains: enrichment writes the real doc
+        // (saved-pages surface) and may assign a domain classification
+        // (domains surface). Projects are unaffected by enrichment.
+        const keysRemoved = await invalidateToolbarSaveCaches(browserApi.storage.local);
+        logger.log('Realtime enrichment relay; invalidated caches', {
+          pageId: message.pageId || null,
+          keysRemoved
         });
       } catch (error) {
         logger.error('Failed to invalidate cache on realtime relay', error);

--- a/src/background.js
+++ b/src/background.js
@@ -11,6 +11,7 @@ import { createLogger, getSafePageContext } from './telemetry.js';
 import { capturePageContent } from './page-capture-injector.js';
 import { addPendingSave } from './pending-saves.js';
 import { applySessionRotation, parseErrorResponse } from './api-core.js';
+import { requestWithAuth } from './api-transport.js';
 import { PROJECTS_CACHE_PREFIX, migrateProjectsCacheKeys, migrateDomainsCacheKeys } from './cache-keys.js';
 
 const logger = createLogger('background');
@@ -197,47 +198,23 @@ const toolbarProjectsStore = new ProjectsStore({
 });
 
 async function fetchBackgroundApi(path = '', { method = 'GET', body, params } = {}) {
-  const { idToken } = await getAuthenticatedSession();
-  const headers = {
-    'Authorization': `Bearer ${idToken}`
-  };
-
-  if (body !== undefined) {
-    headers['Content-Type'] = 'application/json';
-  }
-
-  // Query params are the only way to pass options on a GET — a request body
-  // is ignored by the server and silently dropped. Build a query string like
-  // the newtab path does (api-core _requestWithAuth) so GET requests actually
-  // carry their parameters.
-  let url = `${CONFIG.cloudFunctionUrl}${path}`;
-  if (params) {
-    const searchParams = new URLSearchParams();
-    for (const [key, value] of Object.entries(params)) {
-      if (value !== undefined && value !== null) {
-        searchParams.set(key, String(value));
-      }
-    }
-    const qs = searchParams.toString();
-    if (qs) {
-      url = `${url}?${qs}`;
-    }
-  }
-
-  const response = await fetch(url, {
+  // Delegate to the shared transport (api-transport.js) so the toolbar and the
+  // newtab facade share one authenticated-fetch implementation. The shared
+  // helper handles URL/params building, the Bearer header, error parsing, and
+  // session rotation; this wrapper keeps the background's return shape
+  // (parsed JSON, or null for 204) that its callers depend on.
+  const response = await requestWithAuth({
+    url: path,
+    baseUrl: CONFIG.cloudFunctionUrl,
+    params,
     method,
-    headers,
-    ...(body !== undefined ? { body: JSON.stringify(body) } : {})
+    // The shared transport passes body through verbatim and sets Content-Type,
+    // so pre-serialize here (callers pass plain objects, not JSON strings).
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    getIdToken: async () => (await getAuthenticatedSession()).idToken,
+    onRotation: (res) => applySessionRotation(res, { logger }),
+    parseError: parseErrorResponse
   });
-
-  if (!response.ok) {
-    throw new Error(await parseErrorResponse(response));
-  }
-
-  // Sliding session refresh: the backend rotates the token inline once it
-  // crosses the refresh threshold and returns the replacement here. Store it
-  // so subsequent calls use the new token.
-  await applySessionRotation(response, { logger });
 
   if (response.status === 204) {
     return null;

--- a/src/cache-keys.js
+++ b/src/cache-keys.js
@@ -6,24 +6,33 @@
 
 export const SAVED_PAGES_CACHE_PREFIX = 'savedPages_cache';
 export const PROJECTS_CACHE_PREFIX = 'projects_cache';
+export const DOMAINS_CACHE_PREFIX = 'domains_cache';
 
-// One-time migration: before projects got their own prefix, they were cached
-// under savedPages_cache_* with a surface=projects scope. Those stale keys are
-// now both misleading and invisible to the projects cache manager (which reads
-// projects_cache_*), so evict them. Match narrowly on the projects scope to
-// avoid touching legitimate saved-pages keys.
-export async function migrateProjectsCacheKeys(storage) {
+// One-time migration: before a surface got its own prefix, it was cached under
+// savedPages_cache_* with a surface=<scope> query fragment. Those stale keys
+// are invisible to the surface's own cache manager (which reads <surface>_cache_*),
+// so evict them. Match narrowly on the surface scope to avoid touching
+// legitimate saved-pages keys.
+async function migrateSurfaceCacheKeys(storage, surfaceScope) {
   if (!storage?.get || !storage?.remove) return 0;
 
   const allItems = await storage.get(null);
   const staleKeys = Object.keys(allItems).filter(key => (
     key.startsWith(`${SAVED_PAGES_CACHE_PREFIX}_`) &&
-    key.includes('surface%3Dprojects')
+    key.includes(`surface%3D${surfaceScope}`)
   ));
 
   if (staleKeys.length > 0) {
     await storage.remove(staleKeys);
   }
   return staleKeys.length;
+}
+
+export function migrateProjectsCacheKeys(storage) {
+  return migrateSurfaceCacheKeys(storage, 'projects');
+}
+
+export function migrateDomainsCacheKeys(storage) {
+  return migrateSurfaceCacheKeys(storage, 'domains');
 }
 

--- a/src/newtab-app.js
+++ b/src/newtab-app.js
@@ -343,7 +343,7 @@ export function createNewtabApp({
       elements.refreshBtn?.addEventListener('click', async () => {
         elements.userDropdown?.classList.add('hidden');
         try {
-          await API.invalidateCache();
+          await API.invalidateAllCaches();
           savedPagesStore.setLazy(false);
           void projectsStore.hydrate();
           // forceReload resets hasInitialized + the relevant store and fetches

--- a/src/newtab-page.js
+++ b/src/newtab-page.js
@@ -95,9 +95,19 @@ export async function startNewtabPage({
   // does not auto-reconnect; a page refresh re-establishes it.
   void realtimeClient?.connect();
 
-  // Disconnect when the page is torn down so a bfcache restore doesn't leave
-  // a zombie stream and the server can free the connection promptly.
+  // Lifecycle for bfcache: a pagehide fires both on final teardown and when
+  // the browser stashes the page in the back/forward cache. On a bfcache
+  // restore the page is reused without re-running this init, so we must
+  // reconnect the stream ourselves on pageshow. The listeners persist for the
+  // page's lifetime (not { once: true }) — otherwise a back→forward cycle
+  // leaves the restored page with no teardown and no reconnect.
   globalThis.addEventListener('pagehide', () => {
     realtimeClient?.disconnect();
-  }, { once: true });
+  });
+  globalThis.addEventListener('pageshow', (event) => {
+    // event.persisted is true only on a bfcache restore, not on the initial load.
+    if (event.persisted) {
+      void realtimeClient?.connect();
+    }
+  });
 }

--- a/src/projects-store.js
+++ b/src/projects-store.js
@@ -66,12 +66,15 @@ export class ProjectsStore extends WarmCacheListStore {
       };
     }
 
-    const cacheState = this.api.getCachedPagesState
-      ? await this.api.getCachedPagesState(this.options.warmCacheScope, {
+    // Projects live under their own cache surface (PROJECTS_CACHE_PREFIX), so
+    // route warm-cache reads through the projects-surface methods rather than
+    // the default saved-pages ones inherited from WarmCacheListStore.
+    const cacheState = this.api.getProjectsCachedPagesState
+      ? await this.api.getProjectsCachedPagesState(this.options.warmCacheScope, {
         allowExpired: true
       })
       : await (async () => {
-        const response = await this.api.getCachedPages(this.options.warmCacheScope, {
+        const response = await this.api.getProjectsCachedPages(this.options.warmCacheScope, {
           allowExpired: true
         });
         return {
@@ -126,6 +129,6 @@ export class ProjectsStore extends WarmCacheListStore {
       return;
     }
 
-    await this.api.setCachedPages(this.state.allPages, this.options.warmCacheScope);
+    await this.api.setProjectsCachedPages(this.state.allPages, this.options.warmCacheScope);
   }
 }

--- a/src/realtime-client.js
+++ b/src/realtime-client.js
@@ -17,7 +17,26 @@ export class RealtimeClient {
     this.buffer = '';
   }
 
+  // Whether a stream is currently open. Callers (e.g. the newtab pagehide /
+  // pageshow lifecycle) use this to decide whether to connect after a bfcache
+  // restore without orphaning an existing stream.
+  isConnected() {
+    return this.controller !== null && !this.disconnected;
+  }
+
   async connect() {
+    // Idempotent guard: if a stream is already open, keep it. Without this,
+    // a second connect() (e.g. a pageshow bfcache-restore firing while the
+    // original stream is still alive) would create a fresh AbortController
+    // and orphan the previous one, leaking the connection.
+    if (this.isConnected()) {
+      return;
+    }
+
+    // Reset the disconnect flag from any prior lifecycle so a fresh stream
+    // can toast again if it later drops. (disconnect() sets this to suppress
+    // the toast on intentional teardown.)
+    this.disconnected = false;
     this.controller = new AbortController();
 
     try {

--- a/src/saved-pages-cache.js
+++ b/src/saved-pages-cache.js
@@ -1,8 +1,14 @@
-import { SAVED_PAGES_CACHE_PREFIX } from './cache-keys.js';
+import { SAVED_PAGES_CACHE_PREFIX, DOMAINS_CACHE_PREFIX } from './cache-keys.js';
 
 export function getSavedPagesCacheKeys(storageEntries = {}) {
   return Object.keys(storageEntries).filter(key => (
     key === SAVED_PAGES_CACHE_PREFIX || key.startsWith(`${SAVED_PAGES_CACHE_PREFIX}_`)
+  ));
+}
+
+function getCacheKeysForPrefix(storageEntries, prefix) {
+  return Object.keys(storageEntries).filter(key => (
+    key === prefix || key.startsWith(`${prefix}_`)
   ));
 }
 
@@ -18,6 +24,37 @@ export async function invalidateSavedPagesCacheStorage(storage) {
   }
 
   return cacheKeys.length;
+}
+
+// Storage-direct invalidation for the domains surface. The toolbar save path
+// (background.js) doesn't load the full API facade, so it can't call
+// API.invalidateDomainsCache(); this helper gives it the same narrow-scope
+// eviction via storage.local directly. A new save can shift domain counts, so
+// the toolbar save and realtime-enrichment relay invalidate both surfaces.
+export async function invalidateDomainsCacheStorage(storage) {
+  if (!storage?.get || !storage?.remove) {
+    return 0;
+  }
+
+  const storageEntries = await storage.get(null);
+  const cacheKeys = getCacheKeysForPrefix(storageEntries, DOMAINS_CACHE_PREFIX);
+  if (cacheKeys.length > 0) {
+    await storage.remove(cacheKeys);
+  }
+
+  return cacheKeys.length;
+}
+
+// Invalidate every surface cache the toolbar save path can affect: a new save
+// appears in saved pages and can shift domain counts. Projects are unaffected
+// (a save without a projectId doesn't change project membership). Returns the
+// total number of keys removed across surfaces.
+export async function invalidateToolbarSaveCaches(storage) {
+  const [savedPagesCount, domainsCount] = await Promise.all([
+    invalidateSavedPagesCacheStorage(storage),
+    invalidateDomainsCacheStorage(storage)
+  ]);
+  return savedPagesCount + domainsCount;
 }
 
 export function isSavedPagesCacheInvalidation(changes, areaName) {

--- a/tests/unit/api-transport.test.js
+++ b/tests/unit/api-transport.test.js
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { requestWithAuth, buildRequestUrl } from '../../src/api-transport.js';
+
+// Tests for the single authenticated-fetch implementation shared by the API
+// facade (api-core.js) and the background service worker (background.js).
+// Previously these two paths each inlined their own URL/header/fetch/error/
+// rotation logic; this module is the consolidation.
+describe('api-transport', () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  describe('buildRequestUrl', () => {
+    it('resolves a relative path against baseUrl', () => {
+      expect(buildRequestUrl({ url: '/projects', baseUrl: 'https://api.test' }))
+        .toBe('https://api.test/projects');
+    });
+
+    it('uses an absolute url verbatim', () => {
+      expect(buildRequestUrl({ url: 'https://other.test/x', baseUrl: 'https://api.test' }))
+        .toBe('https://other.test/x');
+    });
+
+    it('appends plain-object params as a query string', () => {
+      expect(buildRequestUrl({ url: '/p', baseUrl: 'https://api.test', params: { a: 1, b: 'two' } }))
+        .toBe('https://api.test/p?a=1&b=two');
+    });
+
+    it('drops null and undefined params', () => {
+      // new URLSearchParams({k:null}) would throw — the filter exists for this.
+      expect(buildRequestUrl({ url: '/p', baseUrl: 'https://api.test', params: { a: null, b: undefined, c: 1 } }))
+        .toBe('https://api.test/p?c=1');
+    });
+
+    it('accepts a URLSearchParams instance unchanged', () => {
+      const sp = new URLSearchParams({ key: 'value' });
+      expect(buildRequestUrl({ url: '/p', baseUrl: 'https://api.test', params: sp }))
+        .toBe('https://api.test/p?key=value');
+    });
+
+    it('omits the ? when params produce an empty string', () => {
+      expect(buildRequestUrl({ url: '/p', baseUrl: 'https://api.test', params: {} }))
+        .toBe('https://api.test/p');
+    });
+  });
+
+  describe('requestWithAuth', () => {
+    function makeResponse({ ok = true, status = 200, json = async () => ({}) } = {}) {
+      return { ok, status, headers: new Map(), json };
+    }
+
+    it('sets the Authorization header from getIdToken', async () => {
+      const fetchMock = vi.fn(async () => makeResponse());
+      global.fetch = fetchMock;
+
+      await requestWithAuth({
+        url: '/x', baseUrl: 'https://api.test',
+        getIdToken: async () => 'abc123'
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.test/x',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer abc123' })
+        })
+      );
+    });
+
+    it('omits Authorization when getIdToken returns null (anonymous caller)', async () => {
+      const fetchMock = vi.fn(async () => makeResponse());
+      global.fetch = fetchMock;
+
+      await requestWithAuth({
+        url: '/x', baseUrl: 'https://api.test',
+        getIdToken: async () => null
+      });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers).not.toHaveProperty('Authorization');
+    });
+
+    it('sets Content-Type and passes body through verbatim when body is present', async () => {
+      const fetchMock = vi.fn(async () => makeResponse());
+      global.fetch = fetchMock;
+      const body = JSON.stringify({ a: 1 });
+
+      await requestWithAuth({
+        url: '/x', baseUrl: 'https://api.test',
+        method: 'POST', body,
+        getIdToken: async () => 'tok'
+      });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.body).toBe(body); // not re-serialized
+      expect(init.headers['Content-Type']).toBe('application/json');
+    });
+
+    it('does not set a body when body is undefined', async () => {
+      const fetchMock = vi.fn(async () => makeResponse());
+      global.fetch = fetchMock;
+
+      await requestWithAuth({
+        url: '/x', baseUrl: 'https://api.test',
+        getIdToken: async () => 'tok'
+      });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init).not.toHaveProperty('body');
+      expect(init.headers).not.toHaveProperty('Content-Type');
+    });
+
+    it('lets caller headers override Content-Type', async () => {
+      const fetchMock = vi.fn(async () => makeResponse());
+      global.fetch = fetchMock;
+
+      await requestWithAuth({
+        url: '/x', baseUrl: 'https://api.test',
+        method: 'POST', body: '{}',
+        headers: { 'Content-Type': 'text/plain' },
+        getIdToken: async () => 'tok'
+      });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers['Content-Type']).toBe('text/plain');
+    });
+
+    it('throws with .status attached on a non-ok response, using parseError', async () => {
+      global.fetch = vi.fn(async () => makeResponse({ ok: false, status: 404 }));
+
+      await expect(requestWithAuth({
+        url: '/x', baseUrl: 'https://api.test',
+        getIdToken: async () => 'tok',
+        parseError: async () => 'Not found'
+      })).rejects.toMatchObject({ message: 'Not found', status: 404 });
+    });
+
+    it('falls back to an HTTP-status message when no parseError is given', async () => {
+      global.fetch = vi.fn(async () => makeResponse({ ok: false, status: 500 }));
+
+      await expect(requestWithAuth({
+        url: '/x', baseUrl: 'https://api.test',
+        getIdToken: async () => 'tok'
+      })).rejects.toThrow('HTTP 500');
+    });
+
+    it('invokes onRotation with the successful response', async () => {
+      const response = makeResponse();
+      global.fetch = vi.fn(async () => response);
+      const onRotation = vi.fn(async () => {});
+
+      await requestWithAuth({
+        url: '/x', baseUrl: 'https://api.test',
+        getIdToken: async () => 'tok',
+        onRotation
+      });
+
+      expect(onRotation).toHaveBeenCalledWith(response);
+    });
+
+    it('does not invoke onRotation on a failed request (it throws first)', async () => {
+      global.fetch = vi.fn(async () => makeResponse({ ok: false, status: 500 }));
+      const onRotation = vi.fn();
+
+      await expect(requestWithAuth({
+        url: '/x', baseUrl: 'https://api.test',
+        getIdToken: async () => 'tok',
+        onRotation
+      })).rejects.toThrow();
+
+      expect(onRotation).not.toHaveBeenCalled();
+    });
+
+    it('returns the raw Response for the caller to decode', async () => {
+      const response = makeResponse({ json: async () => ({ ok: true }) });
+      global.fetch = vi.fn(async () => response);
+
+      const result = await requestWithAuth({
+        url: '/x', baseUrl: 'https://api.test',
+        getIdToken: async () => 'tok'
+      });
+
+      expect(result).toBe(response);
+      expect(await result.json()).toEqual({ ok: true });
+    });
+  });
+});

--- a/tests/unit/api/cache-isolation.test.js
+++ b/tests/unit/api/cache-isolation.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createApiTestHarness } from './test-api-harness.js';
+
+// Verifies the per-surface cache isolation invariant: a mutation on one
+// surface invalidates only that surface's cache (plus any other surface whose
+// data it can change), not every surface wholesale. This is the fix for the
+// architectural finding that "every mutation nukes the whole user cache".
+describe('API - per-surface cache isolation', () => {
+  let API;
+  let harness;
+  let originalWindow;
+
+  beforeEach(() => {
+    originalWindow = { ...global.window };
+    global.window = {
+      firebaseAuth: { currentUser: { uid: 'user123' } },
+      firebaseReady: null,
+      firebaseGetIdToken: vi.fn(async () => 'token'),
+      SentryHelpers: null
+    };
+
+    harness = createApiTestHarness({ cloudFunctionUrl: 'https://test.run.app' });
+    harness.setExtensionMode({ local: {} }, { id: 'test' });
+    API = harness.API;
+
+    // Stand up three distinct mock managers so we can assert which surface
+    // each mutation touched. Each tracks its own invalidateCache calls.
+    API._cacheManager = { invalidateCache: vi.fn(async () => {}) };
+    API._projectsCacheManager = { invalidateCache: vi.fn(async () => {}) };
+    API._domainsCacheManager = { invalidateCache: vi.fn(async () => {}) };
+
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ id: 'ok' })
+    }));
+  });
+
+  afterEach(() => {
+    global.window = originalWindow;
+    vi.clearAllMocks();
+  });
+
+  it('createProject invalidates only the projects surface', async () => {
+    await API.createProject({ name: 'New project' });
+
+    expect(API._projectsCacheManager.invalidateCache).toHaveBeenCalledTimes(1);
+    // A project create does not touch saved pages or domains.
+    expect(API._cacheManager.invalidateCache).not.toHaveBeenCalled();
+    expect(API._domainsCacheManager.invalidateCache).not.toHaveBeenCalled();
+  });
+
+  it('updateProject invalidates only the projects surface', async () => {
+    await API.updateProject('project-1', { name: 'Renamed' });
+
+    expect(API._projectsCacheManager.invalidateCache).toHaveBeenCalledTimes(1);
+    expect(API._cacheManager.invalidateCache).not.toHaveBeenCalled();
+    expect(API._domainsCacheManager.invalidateCache).not.toHaveBeenCalled();
+  });
+
+  it('pinPage invalidates only the saved-pages surface', async () => {
+    await API.pinPage('page-1', true);
+
+    expect(API._cacheManager.invalidateCache).toHaveBeenCalledTimes(1);
+    // Pinning does not change project membership or domain counts.
+    expect(API._projectsCacheManager.invalidateCache).not.toHaveBeenCalled();
+    expect(API._domainsCacheManager.invalidateCache).not.toHaveBeenCalled();
+  });
+
+  it('deletePage invalidates saved-pages and domains (not projects)', async () => {
+    await API.deletePage('page-1');
+
+    expect(API._cacheManager.invalidateCache).toHaveBeenCalledTimes(1);
+    expect(API._domainsCacheManager.invalidateCache).toHaveBeenCalledTimes(1);
+    // Deleting a page does not change project membership.
+    expect(API._projectsCacheManager.invalidateCache).not.toHaveBeenCalled();
+  });
+
+  it('addPageToProject invalidates both projects and saved-pages', async () => {
+    await API.addPageToProject('project-1', 'page-1');
+
+    // Membership changes the projects cache; the page's project_ids changes
+    // the saved-pages cache.
+    expect(API._projectsCacheManager.invalidateCache).toHaveBeenCalledTimes(1);
+    expect(API._cacheManager.invalidateCache).toHaveBeenCalledTimes(1);
+    expect(API._domainsCacheManager.invalidateCache).not.toHaveBeenCalled();
+  });
+
+  it('invalidateAllCaches touches every surface', async () => {
+    await API.invalidateAllCaches();
+
+    expect(API._cacheManager.invalidateCache).toHaveBeenCalledTimes(1);
+    expect(API._projectsCacheManager.invalidateCache).toHaveBeenCalledTimes(1);
+    expect(API._domainsCacheManager.invalidateCache).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/api/cached-or-fresh-list.test.js
+++ b/tests/unit/api/cached-or-fresh-list.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createApiTestHarness } from './test-api-harness.js';
+
+// Focused tests for the shared cached-read flow (_getCachedOrFreshList) that
+// backs getSavedPages, getProjects, and getDomains. Each surface previously
+// inlined its own copy; this locks in the shared contract.
+describe('API - _getCachedOrFreshList (shared cached-read flow)', () => {
+  let API;
+  let harness;
+  let originalWindow;
+
+  beforeEach(() => {
+    originalWindow = { ...global.window };
+    global.window = {
+      firebaseAuth: null,
+      firebaseReady: null,
+      firebaseGetIdToken: null,
+      SentryHelpers: null
+    };
+    harness = createApiTestHarness({ cloudFunctionUrl: 'https://test.run.app' });
+    API = harness.API;
+  });
+
+  afterEach(() => {
+    global.window = originalWindow;
+    vi.restoreAllMocks();
+  });
+
+  function setupExtension() {
+    harness.setExtensionMode({ local: {} }, { id: 'test' });
+  }
+
+  describe('extension mode', () => {
+    it('returns the cached value as-is on a cache hit (no re-normalization)', async () => {
+      setupExtension();
+      const cached = { value: 'cached', preserved: true };
+
+      const result = await API._getCachedOrFreshList({
+        cacheScope: { surface: 'test' },
+        readCache: vi.fn(async () => cached),
+        writeCache: vi.fn(async () => {}),
+        fetcher: vi.fn(async () => { throw new Error('should not fetch on cache hit'); }),
+        normalize: vi.fn(() => { throw new Error('should not normalize on cache hit'); }),
+        mockFetcher: vi.fn(() => { throw new Error('should not mock in extension mode'); }),
+        context: 'test-context',
+        options: {}
+      });
+
+      // The cached value is returned without re-normalization. For plain
+      // objects _withCacheMetadata spreads into a new object (attaching meta);
+      // for arrays it mutates in place. Either way the cached fields survive.
+      expect(result).toMatchObject(cached);
+      expect(result.meta.fromCache).toBe(true);
+    });
+
+    it('fetches, normalizes, writes the cache, and tags meta on a miss', async () => {
+      setupExtension();
+      const readCache = vi.fn(async () => null);
+      const writeCache = vi.fn(async () => {});
+      const fetcher = vi.fn(async () => ({ raw: 'data' }));
+      const normalize = vi.fn((data) => ({ normalized: data }));
+
+      const result = await API._getCachedOrFreshList({
+        cacheScope: { surface: 'test' },
+        readCache,
+        writeCache,
+        fetcher,
+        normalize,
+        mockFetcher: vi.fn(),
+        context: 'test',
+        options: {}
+      });
+
+      expect(fetcher).toHaveBeenCalled();
+      expect(normalize).toHaveBeenCalledWith({ raw: 'data' });
+      expect(writeCache).toHaveBeenCalledWith({ normalized: { raw: 'data' } }, { surface: 'test' });
+      expect(result).toEqual({ normalized: { raw: 'data' }, meta: { fromCache: false } });
+    });
+
+    it('skips the cache read entirely when options.skipCache is true', async () => {
+      setupExtension();
+      const readCache = vi.fn(async () => ({ value: 'would-be-cached' }));
+      const fetcher = vi.fn(async () => ({ raw: 'fresh' }));
+
+      await API._getCachedOrFreshList({
+        cacheScope: { surface: 'test' },
+        readCache,
+        writeCache: vi.fn(async () => {}),
+        fetcher,
+        normalize: (d) => d,
+        mockFetcher: vi.fn(),
+        context: 'test',
+        options: { skipCache: true }
+      });
+
+      expect(readCache).not.toHaveBeenCalled();
+      expect(fetcher).toHaveBeenCalled();
+    });
+
+    it('preserves the cache value exactly (does not add hasNextPage/nextCursor)', async () => {
+      // Regression guard: a prior version of the helper re-normalized on a
+      // cache hit, which mutated the stored shape (adding pagination fields the
+      // stored payload didn't have). Cache hits must return the stored value
+      // byte-for-byte (apart from the meta tag).
+      setupExtension();
+      const stored = { pages: [{ id: '1' }], pagination: { total: 1 } };
+
+      const result = await API._getCachedOrFreshList({
+        cacheScope: { surface: 'test' },
+        readCache: vi.fn(async () => stored),
+        writeCache: vi.fn(async () => {}),
+        fetcher: vi.fn(),
+        normalize: vi.fn((d) => d),
+        mockFetcher: vi.fn(),
+        context: 'test',
+        options: {}
+      });
+
+      expect(result.pagination).toEqual({ total: 1 });
+      expect(result.pagination).not.toHaveProperty('hasNextPage');
+    });
+  });
+
+  describe('standalone mode', () => {
+    it('falls back to the mock fetcher with fromCache: false', async () => {
+      harness.setStandaloneMode();
+      const mockFetcher = vi.fn(() => ({ value: 'mock' }));
+
+      const result = await API._getCachedOrFreshList({
+        cacheScope: { surface: 'test' },
+        readCache: vi.fn(async () => null),
+        writeCache: vi.fn(async () => {}),
+        fetcher: vi.fn(async () => { throw new Error('should not fetch in standalone'); }),
+        normalize: vi.fn(),
+        mockFetcher,
+        context: 'test',
+        options: {}
+      });
+
+      expect(mockFetcher).toHaveBeenCalled();
+      expect(result.meta.fromCache).toBe(false);
+    });
+  });
+});

--- a/tests/unit/api/crud-operations.test.js
+++ b/tests/unit/api/crud-operations.test.js
@@ -139,8 +139,11 @@ describe('API - CRUD Operations', () => {
       };
       global.fetch = vi.fn(async () => mockResponse);
 
-      // Mock cache manager
+      // Mock cache managers — deletePage invalidates saved-pages and domains.
       API._cacheManager = {
+        invalidateCache: vi.fn()
+      };
+      API._domainsCacheManager = {
         invalidateCache: vi.fn()
       };
 
@@ -156,6 +159,7 @@ describe('API - CRUD Operations', () => {
         })
       );
       expect(API._cacheManager.invalidateCache).toHaveBeenCalled();
+      expect(API._domainsCacheManager.invalidateCache).toHaveBeenCalled();
       expect(result.success).toBe(true);
     });
 
@@ -206,6 +210,9 @@ describe('API - CRUD Operations', () => {
       API._cacheManager = {
         invalidateCache: vi.fn()
       };
+      API._domainsCacheManager = {
+        invalidateCache: vi.fn()
+      };
 
       const result = await API.updatePage('page-123', { notes: 'New notes' });
 
@@ -222,6 +229,7 @@ describe('API - CRUD Operations', () => {
       );
       expect(result.notes).toBe('New notes');
       expect(API._cacheManager.invalidateCache).toHaveBeenCalled();
+      expect(API._domainsCacheManager.invalidateCache).toHaveBeenCalled();
     });
 
     it('should throw error when page not found in standalone mode', async () => {
@@ -264,7 +272,7 @@ describe('API - CRUD Operations', () => {
         ok: true,
         json: async () => ({ id: 'project-1', name: 'New project', visibility: 'private' })
       }));
-      API._cacheManager = {
+      API._projectsCacheManager = {
         invalidateCache: vi.fn()
       };
 
@@ -286,7 +294,8 @@ describe('API - CRUD Operations', () => {
           body: JSON.stringify({ name: 'New project' })
         })
       );
-      expect(API._cacheManager.invalidateCache).toHaveBeenCalled();
+      // createProject only affects the projects surface.
+      expect(API._projectsCacheManager.invalidateCache).toHaveBeenCalled();
     });
 
     it('should update project in standalone mode', async () => {
@@ -306,7 +315,7 @@ describe('API - CRUD Operations', () => {
         ok: true,
         json: async () => ({ id: 'project-1', visibility: 'private' })
       }));
-      API._cacheManager = {
+      API._projectsCacheManager = {
         invalidateCache: vi.fn()
       };
 
@@ -343,7 +352,7 @@ describe('API - CRUD Operations', () => {
       harness.setCloudFunctionUrl('https://test.run.app');
       global.window.firebaseAuth = { currentUser: { uid: 'user123' } };
       global.window.firebaseGetIdToken = vi.fn(async () => 'token');
-      API._cacheManager = {
+      API._projectsCacheManager = {
         getCachedPages: vi.fn(async () => null),
         setCachedPages: vi.fn(async () => {})
       };
@@ -369,14 +378,14 @@ describe('API - CRUD Operations', () => {
     it('should return cached projects in extension mode when available', async () => {
       harness.setExtensionMode({ local: {} }, { id: 'test' });
 
-      API._cacheManager = {
+      API._projectsCacheManager = {
         getCachedPages: vi.fn(async () => [{ id: 'project-1', name: 'Cached project' }]),
         setCachedPages: vi.fn()
       };
 
       const result = await API.getProjects();
 
-      expect(API._cacheManager.getCachedPages).toHaveBeenCalled();
+      expect(API._projectsCacheManager.getCachedPages).toHaveBeenCalled();
       expect(result).toHaveLength(1);
       expect(result.meta.fromCache).toBe(true);
     });
@@ -386,7 +395,7 @@ describe('API - CRUD Operations', () => {
       harness.setCloudFunctionUrl('https://test.run.app');
       global.window.firebaseAuth = { currentUser: { uid: 'user123' } };
       global.window.firebaseGetIdToken = vi.fn(async () => 'token');
-      API._cacheManager = {
+      API._projectsCacheManager = {
         getCachedPages: vi.fn(async () => null),
         setCachedPages: vi.fn(async () => {})
       };

--- a/tests/unit/api/domains.test.js
+++ b/tests/unit/api/domains.test.js
@@ -22,6 +22,8 @@ describe('API - getDomains', () => {
     harness = createApiTestHarness({ cloudFunctionUrl: 'https://test-function.run.app' });
     API = harness.API;
     API._cacheManager = null;
+    API._projectsCacheManager = null;
+    API._domainsCacheManager = null;
     vi.clearAllMocks();
   });
 
@@ -77,7 +79,7 @@ describe('API - getDomains', () => {
       const cachedDomains = [
         { domain: 'cached.example', count: 5 }
       ];
-      API._cacheManager = {
+      API._domainsCacheManager = {
         getCachedPages: vi.fn(async () => cachedDomains),
         setCachedPages: vi.fn()
       };
@@ -87,7 +89,7 @@ describe('API - getDomains', () => {
       expect(result).toBe(cachedDomains);
       expect(result.meta).toEqual({ fromCache: true });
       // Cache hit must short-circuit before a network fetch.
-      expect(API._cacheManager.setCachedPages).not.toHaveBeenCalled();
+      expect(API._domainsCacheManager.setCachedPages).not.toHaveBeenCalled();
     });
 
     it('fetches and caches domains on a cache miss', async () => {
@@ -100,7 +102,7 @@ describe('API - getDomains', () => {
         ok: true,
         json: async () => ({ domains: fetchedDomains })
       }));
-      API._cacheManager = {
+      API._domainsCacheManager = {
         getCachedPages: vi.fn(async () => null),
         setCachedPages: vi.fn()
       };
@@ -110,7 +112,7 @@ describe('API - getDomains', () => {
       expect(result).toEqual(fetchedDomains);
       expect(result.meta).toEqual({ fromCache: false });
       // The fetched batch must be written back to the cache.
-      expect(API._cacheManager.setCachedPages).toHaveBeenCalledWith(
+      expect(API._domainsCacheManager.setCachedPages).toHaveBeenCalledWith(
         fetchedDomains,
         { surface: 'domains' }
       );
@@ -126,7 +128,7 @@ describe('API - getDomains', () => {
         json: async () => ({ domains: [{ domain: 'skipped-cache', count: 1 }] })
       }));
       const cachedDomains = [{ domain: 'stale.example', count: 9 }];
-      API._cacheManager = {
+      API._domainsCacheManager = {
         getCachedPages: vi.fn(async () => cachedDomains),
         setCachedPages: vi.fn()
       };
@@ -134,7 +136,7 @@ describe('API - getDomains', () => {
       const result = await API.getDomains({ skipCache: true });
 
       // skipCache must skip the read entirely and go to the network.
-      expect(API._cacheManager.getCachedPages).not.toHaveBeenCalled();
+      expect(API._domainsCacheManager.getCachedPages).not.toHaveBeenCalled();
       expect(global.fetch).toHaveBeenCalled();
       expect(result[0].domain).toBe('skipped-cache');
     });
@@ -148,7 +150,7 @@ describe('API - getDomains', () => {
         ok: true,
         json: async () => ({})
       }));
-      API._cacheManager = {
+      API._domainsCacheManager = {
         getCachedPages: vi.fn(async () => null),
         setCachedPages: vi.fn()
       };
@@ -167,7 +169,7 @@ describe('API - getDomains', () => {
       global.fetch = vi.fn(async () => {
         throw new Error('network down');
       });
-      API._cacheManager = {
+      API._domainsCacheManager = {
         getCachedPages: vi.fn(async () => null),
         setCachedPages: vi.fn()
       };
@@ -176,7 +178,7 @@ describe('API - getDomains', () => {
       // underlying error must propagate rather than being swallowed.
       await expect(API.getDomains()).rejects.toThrow('network down');
       // Nothing should be written to the cache when the fetch failed.
-      expect(API._cacheManager.setCachedPages).not.toHaveBeenCalled();
+      expect(API._domainsCacheManager.setCachedPages).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/cache-keys.test.js
+++ b/tests/unit/cache-keys.test.js
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   SAVED_PAGES_CACHE_PREFIX,
   PROJECTS_CACHE_PREFIX,
-  migrateProjectsCacheKeys
+  DOMAINS_CACHE_PREFIX,
+  migrateProjectsCacheKeys,
+  migrateDomainsCacheKeys
 } from '../../src/cache-keys.js';
 
 function makeStorage(entries) {
@@ -20,7 +22,41 @@ describe('cache-keys constants', () => {
   it('exports distinct prefixes for each surface', () => {
     expect(SAVED_PAGES_CACHE_PREFIX).toBe('savedPages_cache');
     expect(PROJECTS_CACHE_PREFIX).toBe('projects_cache');
-    expect(SAVED_PAGES_CACHE_PREFIX).not.toBe(PROJECTS_CACHE_PREFIX);
+    expect(DOMAINS_CACHE_PREFIX).toBe('domains_cache');
+    expect(new Set([SAVED_PAGES_CACHE_PREFIX, PROJECTS_CACHE_PREFIX, DOMAINS_CACHE_PREFIX]).size).toBe(3);
+  });
+});
+
+describe('migrateDomainsCacheKeys', () => {
+  it('removes stale domains keys written under the savedPages prefix', async () => {
+    const storage = makeStorage({
+      'savedPages_cache_user1_surface%3Ddomains': { response: [] },
+      'savedPages_cache_user1_surface%3Ddashboard': { response: [] },
+      'domains_cache_user1_surface%3Ddomains': { response: [] }
+    });
+
+    const removed = await migrateDomainsCacheKeys(storage);
+
+    expect(removed).toBe(1);
+    expect(storage._data['savedPages_cache_user1_surface%3Ddomains']).toBeUndefined();
+    // Legitimate saved-pages keys must survive.
+    expect(storage._data['savedPages_cache_user1_surface%3Ddashboard']).toBeDefined();
+    // New-namespace keys are untouched.
+    expect(storage._data['domains_cache_user1_surface%3Ddomains']).toBeDefined();
+  });
+
+  it('is a no-op when no stale keys exist', async () => {
+    const storage = makeStorage({
+      'domains_cache_user1_surface%3Ddomains': {},
+      'savedPages_cache_user1_surface%3Ddashboard': {}
+    });
+
+    expect(await migrateDomainsCacheKeys(storage)).toBe(0);
+  });
+
+  it('returns 0 when storage is unavailable', async () => {
+    expect(await migrateDomainsCacheKeys(null)).toBe(0);
+    expect(await migrateDomainsCacheKeys({})).toBe(0);
   });
 });
 

--- a/tests/unit/projects-store.test.js
+++ b/tests/unit/projects-store.test.js
@@ -21,8 +21,10 @@ describe('ProjectsStore', () => {
     ], false);
     const api = {
       isExtension: true,
-      getCachedPages: vi.fn(async () => cachedProjects),
-      setCachedPages: vi.fn(async () => {}),
+      // ProjectsStore reads/writes its warm cache via the projects-surface
+      // methods (PROJECTS_CACHE_PREFIX), not the inherited saved-pages ones.
+      getProjectsCachedPages: vi.fn(async () => cachedProjects),
+      setProjectsCachedPages: vi.fn(async () => {}),
       getProjects: vi
         .fn()
         .mockResolvedValueOnce(freshProjects)
@@ -37,7 +39,7 @@ describe('ProjectsStore', () => {
     });
 
     expect(api.getProjects).toHaveBeenCalledWith({ skipCache: true });
-    expect(api.setCachedPages).toHaveBeenCalledWith(
+    expect(api.setProjectsCachedPages).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({ id: 'project-1', name: 'Fresh project' })
       ]),

--- a/tests/unit/realtime-client.test.js
+++ b/tests/unit/realtime-client.test.js
@@ -174,4 +174,58 @@ describe('RealtimeClient', () => {
     expect(capturedSignal.aborted).toBe(true);
     expect(notify).not.toHaveBeenCalled();  // manual disconnect does not toast
   });
+
+  test('isConnected reflects the stream state across the lifecycle', async () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}));  // stays open
+    const client = makeClient();
+
+    expect(client.isConnected()).toBe(false);
+
+    client.connect();  // not awaited — the mock never resolves
+    await new Promise(r => setTimeout(r, 10));
+    expect(client.isConnected()).toBe(true);
+
+    client.disconnect();
+    expect(client.isConnected()).toBe(false);
+  });
+
+  test('connect is idempotent: a second connect while open does not open a second stream', async () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}));  // stays open
+    const client = makeClient();
+
+    client.connect();
+    await new Promise(r => setTimeout(r, 10));
+    await client.connect();  // second call while the first is still open
+
+    // Exactly one fetch — the second connect early-returned without orphaning
+    // the first stream's AbortController.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('after disconnect, connect reopens the stream and re-arms the disconnect toast', async () => {
+    // First connect: stream closes immediately → toast fires.
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      body: makeReadableStream([]),
+      headers: new Map()
+    });
+    const client = makeClient();
+    await client.connect();
+    await new Promise(r => setTimeout(r, 10));
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    // The stream has ended and disconnected; reconnect must succeed and the
+    // toast must fire again when the second stream also closes.
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      body: makeReadableStream([]),
+      headers: new Map()
+    });
+    await client.connect();
+    await new Promise(r => setTimeout(r, 10));
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(notify).toHaveBeenCalledTimes(2);  // re-armed after the reconnect
+  });
 });


### PR DESCRIPTION
Cleanup pass addressing the top findings from the main-branch architectural review.

## Summary

Five workstreams, each a separate commit for review/rollback:

### 1. Per-surface CacheManagers with scoped invalidation
The facade's single lazy `CacheManager` backed saved-pages, projects, and domains under one prefix. Every mutation (`invalidateCache()` with no scope) nuked all three surfaces on a single edit. Now three lazy instances with distinct prefixes (`savedPages_cache`, `projects_cache`, `domains_cache`), and mutations invalidate only the surfaces they can actually change:

- `createProject`/`updateProject` → projects only
- `pinPage` → saved-pages only
- `deletePage`/`updatePage` → saved-pages + domains (classification shifts affect domain counts)
- `addPageToProject`/`removePageFromProject` → projects + saved-pages (membership vs `project_ids`)
- bulk import → saved-pages + projects

The toolbar save path and realtime relay use new storage-direct helpers (`invalidateToolbarSaveCaches`) since the background doesn't load the facade. Satisfies caching-redux rules #6 and #8.

### 2. Shared authenticated transport
`api-core._requestWithAuth` and `background.fetchBackgroundApi` duplicated URL-building, Bearer headers, error parsing, and session rotation. New \`src/api-transport.js\` is the single \`requestWithAuth\` both compose with their own token getter and rotation callback. Pure module, no facade dependency. No behavior change — one implementation instead of two.

### 3. Realtime bfcache fix (latent bug)
The \`pagehide\` listener was \`{ once: true }\`, so a bfcache-restored page had no teardown and no reconnect. Now persistent \`pagehide\`/\`pageshow\` listeners reconnect on bfcache restore, and \`connect()\` is idempotent (a second call while a stream is open can't orphan the previous \`AbortController\`).

### 4. API-layer shared-helper consolidation
- **4.1:** \`_withCacheMetadata\` is now shape-aware (arrays use defineProperty to preserve array-ness; objects use spread) — deleted two local copies.
- **4.2:** \`_getCachedOrFreshList\` extracted to \`api-core.js\` — the saved-pages, projects, and domains surfaces all delegate to it. Cache hits return stored values as-is (no re-normalization).
- **4.3 (deferred):** search pagination normalization — the search path uses a different result key (\`results\` vs \`pages\`) and offset-based pagination, and its consumer depends on the current shape. Forcing it through \`normalizePagesResponse\` would break the consumer. Noted as intentional divergence.

### 5. AGENTS.md sync
New sections documenting the per-surface cache architecture, the shared transport, and the realtime lifecycle contract. The six backend debt items are unchanged (out of scope).

## Test plan
- [x] \`just check\` — 683 tests pass (30 new), 0 lint errors, bundles build, no CSP violations
- [x] New tests: \`cache-isolation.test.js\`, \`api-transport.test.js\`, \`cached-or-fresh-list.test.js\`, extended \`realtime-client.test.js\` and \`cache-keys.test.js\`
- [ ] Manual smoke (post-merge): load unpacked in Brave; verify save → project cache survives, edit project → saved-pages cache survives, bfcache back/forward → realtime still works

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/airteamaus/codesmith/saveit-extension/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786839857&installation_id=147084415&pr_number=30&repository=airteamaus%2Fsaveit-extension&return_to=https%3A%2F%2Fgithub.com%2Fairteamaus%2Fsaveit-extension%2Fpull%2F30&signature=bef26e57b15a8d045b26fb35b90577902f614970e590917b9c4967139aa1b128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->