### PR TITLE
test(e2e): fix broken import test for Data & sync centre

### DIFF
--- a/tests/e2e/standalone.spec.js
+++ b/tests/e2e/standalone.spec.js
@@ -380,9 +380,12 @@ test.describe('Standalone Mode', () => {
     expect(archiveRed).toBeGreaterThan(150); // red channel dominant (#dc2626 = 220)
   });
 
-  test('imports bookmarks via the import panel: preview → progress → result', async ({ page }) => {
+  test('imports bookmarks via the Data & sync centre', async ({ page }) => {
     // Inject a fake bookmarks tree before the page boots. Standalone mode has
     // no real browser.bookmarks API, so the reader would otherwise throw.
+    // The tree includes two invalid/duplicate entries (a javascript: bookmarklet
+    // and a github.com duplicate) that readAllBookmarks filters out before
+    // import, leaving two importable: github + HN.
     await page.addInitScript(() => {
       const fakeTree = [
         {
@@ -401,26 +404,31 @@ test.describe('Standalone Mode', () => {
 
     await openStandaloneNewtab(page);
 
-    // Import lives behind the avatar dropdown. Reveal the menu (hidden until
-    // signed in in real use) and open the dropdown, then click Import.
+    // The Data & sync centre lives behind the avatar dropdown. Reveal the menu
+    // (hidden until signed in in real use) and open the dropdown, then click
+    // the Data & sync entry.
     await page.evaluate(() => {
       document.getElementById('hero-user-menu')?.classList.remove('hidden');
       document.getElementById('hero-user-dropdown')?.classList.remove('hidden');
     });
-    await page.locator('#hero-import-btn').click();
+    await page.locator('#hero-data-sync-btn').click();
 
-    // Preview step: shows 2 importable (github + HN), 2 skipped (bookmarklet + dup).
-    const dialog = page.locator('#import-panel-dialog');
+    // The modal opens with its three sections (Import / Export / Browser sync).
+    const dialog = page.locator('#data-sync-centre-dialog');
     await expect(dialog).toBeVisible({ timeout: 5000 });
-    await expect(dialog).toContainText('2 to import');
-    await expect(dialog).toContainText('Import 2 bookmarks');
+    await expect(dialog).toContainText('Data & sync');
 
-    // Run the import — standalone mock returns success immediately.
-    await dialog.locator('button', { hasText: 'Import 2 bookmarks' }).click();
+    // Trigger the browser-bookmarks import. The new flow has no preview step —
+    // readAllBookmarks filters/dedupes, then runImport posts the batch and the
+    // modal closes on success, surfacing a confirmation toast.
+    await dialog.locator('button', { hasText: 'From this browser' }).click();
 
-    // Result step: complete with counts.
-    await expect(dialog).toContainText('Import complete', { timeout: 5000 });
-    await expect(dialog).toContainText('Imported 2 bookmarks');
+    // The modal closes and a success toast appears in the toast region. The
+    // standalone bulkImport mock returns { imported: 2, skipped: 0 }, so the
+    // "Import complete" path runs (the warning variant only fires when the
+    // backend reports skips).
+    await expect(dialog).toBeHidden({ timeout: 5000 });
+    await expect(page.locator('#toast-region')).toContainText('Import complete', { timeout: 5000 });
   });
 
   test('renders a Domains section in the sidebar and scopes on click', async ({ page }) => {


### PR DESCRIPTION
Fixes the E2E test that's been broken on main since v1.23.0 (the Data & sync overhaul, \`e4ac091\`).

The test clicked \`#hero-import-btn\` and asserted against \`#import-panel-dialog\`, but the overhaul renamed the button to \`#hero-data-sync-btn\` and replaced the old import-panel preview flow with the consolidated Data & sync centre. The test was never updated.

## What changed

Rewrote the test to match the current flow:
1. Open the Data & sync centre via \`#hero-data-sync-btn\` (avatar dropdown)
2. Assert \`#data-sync-centre-dialog\` opens with the 'Data & sync' title
3. Click 'From this browser's bookmarks' (the new flow has no preview step — \`readAllBookmarks\` filters/dedupes, then \`runImport\` posts the batch)
4. Assert the modal closes and the success toast shows 'Import complete' in \`#toast-region\`

The fake bookmarks tree (github, HN, javascript: bookmarklet, github duplicate) is unchanged — the reader still filters to 2 importable. The standalone mock returns \`{ imported: 2, skipped: 0 }\` so the success path runs.

## Verification
- [x] All 16 \`standalone.spec.js\` tests pass locally (was 15 pass + 1 fail)
- [x] No production code changed — test-only fix

## Note
The \`warming-flow.spec.js\` failures observed in CI are pre-existing flakes in a separate real-extension Chromium test; this PR doesn't touch warming code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/airteamaus/codesmith/saveit-extension/pr/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786840964&installation_id=147084415&pr_number=31&repository=airteamaus%2Fsaveit-extension&return_to=https%3A%2F%2Fgithub.com%2Fairteamaus%2Fsaveit-extension%2Fpull%2F31&signature=009ead182df6709610a2846aa909afb7b7b516c765098b526173533739ea1c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->